### PR TITLE
Add syntax examples to commands for LLM to read

### DIFF
--- a/src/main/java/adris/altoclef/commands/EquipCommand.java
+++ b/src/main/java/adris/altoclef/commands/EquipCommand.java
@@ -10,7 +10,7 @@ import net.minecraft.item.Item;
 
 public class EquipCommand extends Command {
     public EquipCommand() throws CommandException {
-        super("equip", "Equips items", new Arg<>(ItemList.class, "[equippable_items]"));
+        super("equip", "Equips items. Example; `equip iron_chestplate` equips an iron chestplate.", new Arg<>(ItemList.class, "[equippable_items]"));
     }
 
     @Override

--- a/src/main/java/adris/altoclef/commands/FollowCommand.java
+++ b/src/main/java/adris/altoclef/commands/FollowCommand.java
@@ -9,7 +9,7 @@ import adris.altoclef.tasks.movement.FollowPlayerTask;
 
 public class FollowCommand extends Command {
     public FollowCommand() throws CommandException {
-        super("follow", "Follows you or someone else", new Arg(String.class, "username", null, 0));
+        super("follow", "Follows you or someone else. Example: `follow Player` to follow player with username=Player", new Arg(String.class, "username", null, 0));
     }
 
     @Override

--- a/src/main/java/adris/altoclef/commands/FoodCommand.java
+++ b/src/main/java/adris/altoclef/commands/FoodCommand.java
@@ -9,7 +9,7 @@ import adris.altoclef.tasks.resources.CollectFoodTask;
 
 public class FoodCommand extends Command {
     public FoodCommand() throws CommandException {
-        super("food", "Collects a certain amount of food", new Arg<>(Integer.class, "count"));
+        super("food", "Collects a certain amount of food. Example: `food 10` to collect 10 units of food.", new Arg<>(Integer.class, "count"));
     }
 
     @Override

--- a/src/main/java/adris/altoclef/commands/GetCommand.java
+++ b/src/main/java/adris/altoclef/commands/GetCommand.java
@@ -2,14 +2,18 @@ package adris.altoclef.commands;
 
 import adris.altoclef.AltoClef;
 import adris.altoclef.TaskCatalogue;
-import adris.altoclef.commandsystem.*;
+import adris.altoclef.commandsystem.Arg;
+import adris.altoclef.commandsystem.ArgParser;
+import adris.altoclef.commandsystem.Command;
+import adris.altoclef.commandsystem.CommandException;
+import adris.altoclef.commandsystem.ItemList;
 import adris.altoclef.tasksystem.Task;
 import adris.altoclef.util.ItemTarget;
 
 public class GetCommand extends Command {
 
     public GetCommand() throws CommandException {
-        super("get", "Get an item/resource. Examples: `@get log 20` gets 20 logs, `@get diamond_chestplate 1` gets 1 diamond chestplate. Not all resources are gettable", new Arg<>(ItemList.class, "items"));
+        super("get", "Get a resource, Get / Craft an item. Examples: `@get log 20` gets 20 logs, `get diamond_chestplate 1` gets 1 diamond chestplate.", new Arg<>(ItemList.class, "items"));
     }
 
 

--- a/src/main/java/adris/altoclef/commands/GetCommand.java
+++ b/src/main/java/adris/altoclef/commands/GetCommand.java
@@ -9,7 +9,7 @@ import adris.altoclef.util.ItemTarget;
 public class GetCommand extends Command {
 
     public GetCommand() throws CommandException {
-        super("get", "Get an item/resource", new Arg<>(ItemList.class, "items"));
+        super("get", "Get an item/resource. Examples: `@get log 20` gets 20 logs, `@get diamond_chestplate 1` gets 1 diamond chestplate. Not all resources are gettable", new Arg<>(ItemList.class, "items"));
     }
 
 

--- a/src/main/java/adris/altoclef/commands/GiveCommand.java
+++ b/src/main/java/adris/altoclef/commands/GiveCommand.java
@@ -14,7 +14,7 @@ import net.minecraft.item.ItemStack;
 
 public class GiveCommand extends Command {
     public GiveCommand() throws CommandException {
-        super("give", "Collects an item and gives it to you or someone else", new Arg(String.class, "username", null, 2), new Arg(String.class, "item"), new Arg(Integer.class, "count", 1, 1));
+        super("give", "Collects an item and gives it to you or someone else. Examples: `give Player diamond 3` to give player with username=Player 3 diamonds.", new Arg(String.class, "username", null, 2), new Arg(String.class, "item"), new Arg(Integer.class, "count", 1, 1));
     }
 
     @Override


### PR DESCRIPTION
### Add usage examples to command descriptions in AltoCef bot commands to improve LLM readability
Updates command descriptions in multiple command classes to include clear usage examples:

* [`EquipCommand`](https://github.com/elefant-ai/chatclef/pull/4/files#diff-def4405bc00588af16d9dcdce112a37c5525d0aa4171997ce1df020c237ea31f) adds example `equip iron_chestplate`
* [`FollowCommand`](https://github.com/elefant-ai/chatclef/pull/4/files#diff-c7a0c1bc25dbc7cfb410ebd5f7a4629a60753411d35805b48bfc804c2170fde8) adds example `follow Player`
* [`FoodCommand`](https://github.com/elefant-ai/chatclef/pull/4/files#diff-4429ead0d1283c68ab1c09c5f7c1157866c5a9d256ff36725000bbc54deb70bd) adds example `food 10`
* [`GetCommand`](https://github.com/elefant-ai/chatclef/pull/4/files#diff-1289a3743ff95f8af395c3c92ba4de798ac490aaa55a1b585b604c372ba7290c) adds examples `@get log 20` and `@get diamond_chestplate 1`
* [`GiveCommand`](https://github.com/elefant-ai/chatclef/pull/4/files#diff-fcf9fac2fcc1ccfcad0e040e5b1212eb06b9071463b9863d7f0b481ba86854f0) adds example `give Player diamond 3`

#### 📍Where to Start
Start with the constructor in [`EquipCommand.java`](https://github.com/elefant-ai/chatclef/pull/4/files#diff-def4405bc00588af16d9dcdce112a37c5525d0aa4171997ce1df020c237ea31f) as it represents the simplest command description update pattern that is repeated across all modified files.

----

_[Macroscope](https://app.macroscope.com) summarized 4f142f7._