### PR TITLE
make the idle command use "idle" by default and when it's set to "" (the previous default)

### DIFF
--- a/src/main/java/adris/altoclef/Settings.java
+++ b/src/main/java/adris/altoclef/Settings.java
@@ -295,11 +295,13 @@ public class Settings implements IFailableConfigFile {
     /**
      * If set, will run this command by default when no other commands are running.
      * <p>
+     * For elefant we also consider "" to be "idle" to make things work with other configurations.
+     * Set this to null to actually disable this feature.
      * For example, try setting this to "idle" to make the bot continue surviving/eating/escaping mobs.
      * Or "follow <Your Username>" to follow you when not doing anything.
      * Or "goto <Home base coords>" to return to home base when the bot finishes its work.
      */
-    private String idleCommand = "";
+    private String idleCommand = "idle";
 
 
     /**
@@ -540,7 +542,9 @@ public class Settings implements IFailableConfigFile {
     }
 
     public String getIdleCommand() {
-        return idleCommand;
+        // default to "idle" for users that had the setting at "" before
+        // (they can still disable this by changing the setting to null)
+        return idleCommand == "" ? "idle" : idleCommand;
     }
 
     public String getDeathCommand() {
@@ -548,7 +552,8 @@ public class Settings implements IFailableConfigFile {
     }
 
     public boolean shouldRunIdleCommandWhenNotActive() {
-        return idleCommand != null && !idleCommand.isBlank();
+        String command = getIdleCommand();
+        return command != null && !command.isBlank();
     }
 
     public boolean shouldAutoMLGBucket() {

--- a/src/main/java/adris/altoclef/commands/StopCommand.java
+++ b/src/main/java/adris/altoclef/commands/StopCommand.java
@@ -7,12 +7,14 @@ import adris.altoclef.commandsystem.Command;
 public class StopCommand extends Command {
 
     public StopCommand() {
-        super("stop", "Stop task runner (stops all automation)");
+        super("stop", "Stop task runner (stops all automation), also stops the IDLE task until a new task is started");
     }
 
     @Override
     protected void call(AltoClef mod, ArgParser parser) {
         mod.getUserTaskChain().cancel(mod);
+        // also disable idle, but we can re-enable it as soon as any task runs
+        mod.getTaskRunner().disable();
         finish();
     }
 }

--- a/src/main/java/adris/altoclef/player2api/AICommandBridge.java
+++ b/src/main/java/adris/altoclef/player2api/AICommandBridge.java
@@ -86,7 +86,7 @@ Current Status:
         if (tasks.isEmpty()) {
             currentStatus = ("No tasks currently running.");
         } else {
-            currentStatus = ("CURRENT TASK: " + tasks.get(0).toString());
+            currentStatus = ("RUNNING TASK: " + tasks.get(0).toString());
         }
         String newPrompt = Utils.replacePlaceholders(initialPrompt, Map.of("characterDescription", character.description, "characterName", character.name, "validCommands", validCommandsFormatted, "currentStatus", currentStatus));
         System.out.println("New prompt: "+ newPrompt);


### PR DESCRIPTION
### Set default idle command to "idle" in Settings class while maintaining backward compatibility for empty string values
* Updates `idleCommand` behavior in [Settings.java](https://github.com/elefant-ai/chatclef/pull/5/files#diff-249113e275f5d4f079a50758dfb6e724faab676d61bea923796bb5ba320f6c6b) to use "idle" as default and when empty string is provided, while allowing null to disable the feature
* Enhances `StopCommand` in [StopCommand.java](https://github.com/elefant-ai/chatclef/pull/5/files#diff-412c753649d70dc7b7a4ecbde7c621bb145fc1a7988b82f7cdc133e24d953c8a) to disable task runner until new task starts
* Updates task status display text in [AICommandBridge.java](https://github.com/elefant-ai/chatclef/pull/5/files#diff-35e6fe476eee11fe1ef7db93a91370c235c9aabc37183b806ad4fbb29f71160c) from "CURRENT TASK" to "RUNNING TASK"

#### 📍Where to Start
Start with the `getIdleCommand()` method in [Settings.java](https://github.com/elefant-ai/chatclef/pull/5/files#diff-249113e275f5d4f079a50758dfb6e724faab676d61bea923796bb5ba320f6c6b) which contains the core logic changes for handling idle command behavior.

----

_[Macroscope](https://app.macroscope.com) summarized 105ba3f._