### PR TITLE
Update get command to include user inventory count

### DIFF
--- a/src/main/java/adris/altoclef/commands/GetCommand.java
+++ b/src/main/java/adris/altoclef/commands/GetCommand.java
@@ -1,5 +1,8 @@
 package adris.altoclef.commands;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import adris.altoclef.AltoClef;
 import adris.altoclef.TaskCatalogue;
 import adris.altoclef.commandsystem.Arg;
@@ -16,9 +19,19 @@ public class GetCommand extends Command {
         super("get", "Get a resource, Get / Craft an item. Examples: `get log 20` gets 20 logs, `get diamond_chestplate 1` gets 1 diamond chestplate.", new Arg<>(ItemList.class, "items"));
     }
 
-
     private void getItems(AltoClef mod, ItemTarget... items) {
         Task targetTask;
+
+        List<ItemTarget> resultTargets = new ArrayList<>();
+        for (ItemTarget target : items) {
+            int count = target.getTargetCount();
+            // append to current count so this is workable with the agent
+            count += AltoClef.getInstance().getItemStorage().getItemCountInventoryOnly(target.getMatches());
+
+            resultTargets.add(new ItemTarget(target, count));
+        }
+        items = resultTargets.toArray(new ItemTarget[0]);
+
         if (items == null || items.length == 0) {
             mod.log("You must specify at least one item!");
             finish();


### PR DESCRIPTION
### Modify `GetCommand` to account for existing inventory items when calculating target collection quantities
Updates the `getItems` method in [GetCommand.java](https://github.com/elefant-ai/chatclef/pull/7/files#diff-1289a3743ff95f8af395c3c92ba4de798ac490aaa55a1b585b604c372ba7290c) to calculate adjusted item target counts by adding current inventory quantities to requested amounts. The code creates a new `ArrayList` of `ItemTarget` objects that factor in existing inventory items.

#### 📍Where to Start
Start with the `getItems` method in [GetCommand.java](https://github.com/elefant-ai/chatclef/pull/7/files#diff-1289a3743ff95f8af395c3c92ba4de798ac490aaa55a1b585b604c372ba7290c) which contains the core logic for calculating adjusted item target quantities.

----

_[Macroscope](https://app.macroscope.com) summarized 4317b8a._