### PR TITLE
Make commands consider current item counts to work w/ agent

### DIFF
--- a/src/main/java/adris/altoclef/commands/FoodCommand.java
+++ b/src/main/java/adris/altoclef/commands/FoodCommand.java
@@ -6,6 +6,7 @@ import adris.altoclef.commandsystem.ArgParser;
 import adris.altoclef.commandsystem.Command;
 import adris.altoclef.commandsystem.CommandException;
 import adris.altoclef.tasks.resources.CollectFoodTask;
+import adris.altoclef.util.helpers.StorageHelper;
 
 public class FoodCommand extends Command {
     public FoodCommand() throws CommandException {
@@ -14,6 +15,11 @@ public class FoodCommand extends Command {
 
     @Override
     protected void call(AltoClef mod, ArgParser parser) throws CommandException {
-        mod.runUserTask(new CollectFoodTask(parser.get(Integer.class)), this::finish);
+        int foodPoints = parser.get(Integer.class);
+
+        // agent integration
+        foodPoints += StorageHelper.calculateInventoryFoodScore();
+
+        mod.runUserTask(new CollectFoodTask(foodPoints), this::finish);
     }
 }

--- a/src/main/java/adris/altoclef/commands/GetCommand.java
+++ b/src/main/java/adris/altoclef/commands/GetCommand.java
@@ -1,7 +1,5 @@
 package adris.altoclef.commands;
 
-import java.util.ArrayList;
-import java.util.List;
 
 import adris.altoclef.AltoClef;
 import adris.altoclef.TaskCatalogue;
@@ -10,6 +8,7 @@ import adris.altoclef.commandsystem.ArgParser;
 import adris.altoclef.commandsystem.Command;
 import adris.altoclef.commandsystem.CommandException;
 import adris.altoclef.commandsystem.ItemList;
+import adris.altoclef.player2api.AgentCommandUtils;
 import adris.altoclef.tasksystem.Task;
 import adris.altoclef.util.ItemTarget;
 
@@ -22,15 +21,8 @@ public class GetCommand extends Command {
     private void getItems(AltoClef mod, ItemTarget... items) {
         Task targetTask;
 
-        List<ItemTarget> resultTargets = new ArrayList<>();
-        for (ItemTarget target : items) {
-            int count = target.getTargetCount();
-            // append to current count so this is workable with the agent
-            count += AltoClef.getInstance().getItemStorage().getItemCountInventoryOnly(target.getMatches());
-
-            resultTargets.add(new ItemTarget(target, count));
-        }
-        items = resultTargets.toArray(new ItemTarget[0]);
+        // agent integration
+        items = AgentCommandUtils.addPresentItemsToTargets(items);
 
         if (items == null || items.length == 0) {
             mod.log("You must specify at least one item!");

--- a/src/main/java/adris/altoclef/commands/MeatCommand.java
+++ b/src/main/java/adris/altoclef/commands/MeatCommand.java
@@ -7,6 +7,8 @@ import adris.altoclef.commandsystem.Command;
 import adris.altoclef.commandsystem.CommandException;
 import adris.altoclef.tasks.resources.CollectMeatTask;
 
+import adris.altoclef.util.helpers.ItemHelper;
+
 public class MeatCommand extends Command {
     public MeatCommand() throws CommandException {
         super("meat", "Collects a certain amount of meat", new Arg<>(Integer.class, "count"));
@@ -14,6 +16,10 @@ public class MeatCommand extends Command {
 
     @Override
     protected void call(AltoClef mod, ArgParser parser) throws CommandException {
-        mod.runUserTask(new CollectMeatTask(parser.get(Integer.class)), this::finish);
+        int count = parser.get(Integer.class);
+        // agent integration
+        count += AltoClef.getInstance().getItemStorage().getItemCountInventoryOnly(ItemHelper.COOKED_FOODS );
+
+        mod.runUserTask(new CollectMeatTask(count), this::finish);
     }
 }

--- a/src/main/java/adris/altoclef/commands/MeatCommand.java
+++ b/src/main/java/adris/altoclef/commands/MeatCommand.java
@@ -7,18 +7,19 @@ import adris.altoclef.commandsystem.Command;
 import adris.altoclef.commandsystem.CommandException;
 import adris.altoclef.tasks.resources.CollectMeatTask;
 
-import adris.altoclef.util.helpers.ItemHelper;
+import adris.altoclef.util.helpers.StorageHelper;
 
 public class MeatCommand extends Command {
     public MeatCommand() throws CommandException {
-        super("meat", "Collects a certain amount of meat", new Arg<>(Integer.class, "count"));
+        super("meat", "Collects a certain amount of food units of meat. ex. `@meat 10` collects 10 units of food (half of the entire hunger bar)", new Arg<>(Integer.class, "count"));
     }
 
     @Override
     protected void call(AltoClef mod, ArgParser parser) throws CommandException {
         int count = parser.get(Integer.class);
+
         // agent integration
-        count += AltoClef.getInstance().getItemStorage().getItemCountInventoryOnly(ItemHelper.COOKED_FOODS );
+        count += StorageHelper.calculateInventoryFoodScore();
 
         mod.runUserTask(new CollectMeatTask(count), this::finish);
     }

--- a/src/main/java/adris/altoclef/player2api/AgentCommandUtils.java
+++ b/src/main/java/adris/altoclef/player2api/AgentCommandUtils.java
@@ -1,3 +1,5 @@
+package adris.altoclef.player2api;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/adris/altoclef/player2api/AgentCommandUtils.java
+++ b/src/main/java/adris/altoclef/player2api/AgentCommandUtils.java
@@ -1,0 +1,19 @@
+import java.util.ArrayList;
+import java.util.List;
+
+import adris.altoclef.AltoClef;
+import adris.altoclef.util.ItemTarget;
+
+public class AgentCommandUtils {
+    public static ItemTarget[] addPresentItemsToTargets(ItemTarget[] items) {
+        List<ItemTarget> resultTargets = new ArrayList<>();
+        for (ItemTarget target : items) {
+            int count = target.getTargetCount();
+            // append to current count so this is workable with the agent
+            count += AltoClef.getInstance().getItemStorage().getItemCountInventoryOnly(target.getMatches());
+
+            resultTargets.add(new ItemTarget(target, count));
+        }
+        return resultTargets.toArray(new ItemTarget[0]);
+    }
+}


### PR DESCRIPTION
### Update food and item collection commands to consider current inventory counts when determining target amounts
* Modifies `FoodCommand` and `MeatCommand` to add current inventory food scores to requested amounts in [FoodCommand.java](https://github.com/elefant-ai/chatclef/pull/17/files#diff-4429ead0d1283c68ab1c09c5f7c1157866c5a9d256ff36725000bbc54deb70bd) and [MeatCommand.java](https://github.com/elefant-ai/chatclef/pull/17/files#diff-c63fcc587257244b252fa0aed08139ca7396350aea43f70b913c6d1437931c5f)
* Extracts inventory item counting logic into new `AgentCommandUtils.addPresentItemsToTargets()` utility method in [AgentCommandUtils.java](https://github.com/elefant-ai/chatclef/pull/17/files#diff-5741437fed3b35c21d6cbc68939100b4d88481eb236a028e3dab950ae08b6016)
* Refactors `GetCommand` to use the new utility method for handling inventory counts in [GetCommand.java](https://github.com/elefant-ai/chatclef/pull/17/files#diff-1289a3743ff95f8af395c3c92ba4de798ac490aaa55a1b585b604c372ba7290c)

#### 📍Where to Start
Start with the new utility method `addPresentItemsToTargets()` in [AgentCommandUtils.java](https://github.com/elefant-ai/chatclef/pull/17/files#diff-5741437fed3b35c21d6cbc68939100b4d88481eb236a028e3dab950ae08b6016), as this contains the core functionality that is used by the modified commands.

----

_[Macroscope](https://app.macroscope.com) summarized ecd86e4._