### PR TITLE
fix baritone continuing on idle, make `stop` more general

### DIFF
--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -219,7 +219,19 @@ public class AltoClef implements ModInitializer {
 
         // External mod initialization
         runEnqueuedPostInits();
-}
+    }
+
+    public void stop() {
+        getUserTaskChain().cancel(this);
+        if (taskRunner.getCurrentTaskChain() != null) {
+            taskRunner.getCurrentTaskChain().stop();
+        }
+        // also disable idle, but we can re-enable it as soon as any task runs
+        getTaskRunner().disable();
+        // Extra reset. Sometimes baritone is laggy and doesn't properly reset our press
+        getClientBaritone().getPathingBehavior().forceCancel();
+        getClientBaritone().getInputOverrideHandler().clearAllKeys();
+    }
 
     // Client tick
 
@@ -230,10 +242,7 @@ public class AltoClef implements ModInitializer {
 
         // Cancel shortcut
         if (InputHelper.isKeyPressed(GLFW.GLFW_KEY_LEFT_CONTROL) && InputHelper.isKeyPressed(GLFW.GLFW_KEY_K)) {
-            userTaskChain.cancel(this);
-            if (taskRunner.getCurrentTaskChain() != null) {
-                taskRunner.getCurrentTaskChain().stop();
-            }
+            stop();
         }
 
         // Call heartbeat every 60 seconds

--- a/src/main/java/adris/altoclef/chains/UserTaskChain.java
+++ b/src/main/java/adris/altoclef/chains/UserTaskChain.java
@@ -92,15 +92,17 @@ public class UserTaskChain extends SingleTaskChain {
     @Override
     protected void onTaskFinish(AltoClef mod) {
         boolean shouldIdle = mod.getModSettings().shouldRunIdleCommandWhenNotActive();
-        if (!shouldIdle) {
-            // Stop.
-            mod.getTaskRunner().disable();
-            // Extra reset. Sometimes baritone is laggy and doesn't properly reset our press
-            mod.getClientBaritone().getInputOverrideHandler().clearAllKeys();
-        }
         double seconds = taskStopwatch.time();
         Task oldTask = mainTask;
         mainTask = null;
+        if (!shouldIdle) {
+            // Stop.
+            mod.stop();
+        } else {
+            // disable baritone at least
+            mod.getClientBaritone().getPathingBehavior().forceCancel();
+            mod.getClientBaritone().getInputOverrideHandler().clearAllKeys();    
+        }
         if (currentOnFinish != null) {
             currentOnFinish.run();
         }

--- a/src/main/java/adris/altoclef/commands/StopCommand.java
+++ b/src/main/java/adris/altoclef/commands/StopCommand.java
@@ -12,9 +12,7 @@ public class StopCommand extends Command {
 
     @Override
     protected void call(AltoClef mod, ArgParser parser) {
-        mod.getUserTaskChain().cancel(mod);
-        // also disable idle, but we can re-enable it as soon as any task runs
-        mod.getTaskRunner().disable();
+        mod.stop();
         finish();
     }
 }


### PR DESCRIPTION
### Centralize task stopping logic and fix Baritone idle behavior by implementing `AltoClef.stop()` method
* Introduces a new centralized `stop()` method in [AltoClef.java](https://github.com/elefant-ai/chatclef/pull/19/files#diff-d367ff97b960553c1363b112e7e24e8135753dacd064485925543550cbb31be8) that handles task cancellation, task runner disabling, and Baritone pathing reset
* Updates [UserTaskChain.java](https://github.com/elefant-ai/chatclef/pull/19/files#diff-fcfc441ce06c50d8dac49fd47ba358bd61531b6a8a9acb058c0ef4724d43a288) to use the new `stop()` method and adds explicit Baritone reset logic for idle cases
* Modifies [StopCommand.java](https://github.com/elefant-ai/chatclef/pull/19/files#diff-412c753649d70dc7b7a4ecbde7c621bb145fc1a7988b82f7cdc133e24d953c8a) to utilize the centralized `stop()` method

#### 📍Where to Start
Start with the new `stop()` method implementation in [AltoClef.java](https://github.com/elefant-ai/chatclef/pull/19/files#diff-d367ff97b960553c1363b112e7e24e8135753dacd064485925543550cbb31be8), which is the central point for the task stopping logic changes.

----

_[Macroscope](https://app.macroscope.com) summarized db46fec._