### PR TITLE
Defend against attacking players

### DIFF
--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -150,6 +150,7 @@ public class AltoClef implements ModInitializer {
         new PreEquipItemChain(taskRunner);
         new WorldSurvivalChain(taskRunner);
         foodChain = new FoodChain(taskRunner);
+        new PlayerDefenseChain(taskRunner);
 
         // Trackers
         storageTracker = new ItemStorageTracker(this, trackerManager, container -> containerSubTracker = container);

--- a/src/main/java/adris/altoclef/chains/MobDefenseChain.java
+++ b/src/main/java/adris/altoclef/chains/MobDefenseChain.java
@@ -256,9 +256,11 @@ public class MobDefenseChain extends SingleTaskChain {
                 return 65;
             }
 
-            runAwayTask = new DodgeProjectilesTask(ARROW_KEEP_DISTANCE_HORIZONTAL, ARROW_KEEP_DISTANCE_VERTICAL);
-            setTask(runAwayTask);
-            return 65;
+            if (isProjectileClose(mod)) {
+                runAwayTask = new DodgeProjectilesTask(ARROW_KEEP_DISTANCE_HORIZONTAL, ARROW_KEEP_DISTANCE_VERTICAL);
+                setTask(runAwayTask);
+                return 65;    
+            }
         }
         // Dodge all mobs cause we boutta die son
         if (isInDanger(mod) && !escapeDragonBreath(mod) && !mod.getFoodChain().isShouldStop()) {
@@ -570,14 +572,18 @@ public class MobDefenseChain extends SingleTaskChain {
     private boolean isInDanger(AltoClef mod) {
         boolean witchNearby = mod.getEntityTracker().entityFound(WitchEntity.class);
 
+        double safeKeepDistance = SAFE_KEEP_DISTANCE;
+
+        // get away if there's witches
         float health = mod.getPlayer().getHealth();
-        if (health <= 10 && !witchNearby) {
-            return true;
+        if (health <= 10 && witchNearby) {
+            safeKeepDistance = DANGER_KEEP_DISTANCE;
         }
         if (mod.getPlayer().hasStatusEffect(StatusEffects.WITHER) ||
-                (mod.getPlayer().hasStatusEffect(StatusEffects.POISON) && !witchNearby)) {
-            return true;
+                (mod.getPlayer().hasStatusEffect(StatusEffects.POISON) && witchNearby)) {
+            safeKeepDistance = DANGER_KEEP_DISTANCE;
         }
+
         if (WorldHelper.isVulnerable()) {
             // If hostile mobs are nearby...
             try {
@@ -586,7 +592,7 @@ public class MobDefenseChain extends SingleTaskChain {
 
                 synchronized (BaritoneHelper.MINECRAFT_LOCK) {
                     for (Entity entity : hostiles) {
-                        if (entity.isInRange(player, SAFE_KEEP_DISTANCE)
+                        if (entity.isInRange(player, safeKeepDistance)
                                 && !mod.getBehaviour().shouldExcludeFromForcefield(entity)
                                 && EntityHelper.isAngryAtPlayer(mod, entity)) {
                             return true;

--- a/src/main/java/adris/altoclef/chains/PlayerDefenseChain.java
+++ b/src/main/java/adris/altoclef/chains/PlayerDefenseChain.java
@@ -32,9 +32,9 @@ public class PlayerDefenseChain extends SingleTaskChain {
 
     private void onPlayerDamage(DamageSource source) {
         // TODO: Process and target player
-        Entity damagedBy = source.getSource();
+        Entity damagedBy = source.getAttacker();
         if (damagedBy == null) {
-            System.out.println("ASDF null");
+            return;
         }
         if (damagedBy instanceof PlayerEntity player) {
             String offendingName = player.getName().getString();
@@ -47,6 +47,10 @@ public class PlayerDefenseChain extends SingleTaskChain {
             if (target.forgetInstigationTimer.elapsed()) {
                 target.timesHit = 0;
             }
+            if (target.forgetAttackTimer.elapsed()) {
+                target.attacking = false;
+            }
+
             target.forgetInstigationTimer.reset();
             if (!target.attacking) {
                 target.timesHit++;
@@ -55,6 +59,7 @@ public class PlayerDefenseChain extends SingleTaskChain {
                     System.out.println("Too many attacks from another player! Retaliating attacks against offending player: " + offendingName);
                     target.attacking = true;
                     target.forgetAttackTimer.reset();
+                    target.timesHit = 0;
                     // Always attack the most recently attacked entity, to keep things simple
                     _currentlyAttackingPlayer = offendingName;
                 }
@@ -84,9 +89,8 @@ public class PlayerDefenseChain extends SingleTaskChain {
 
             PlayerEntity potentialPlayer = AltoClef.getInstance().getEntityTracker().getPlayerEntity(potentialAttacker).orElse(null);
 
-            if (potentialPlayer != null && (!potentialPlayer.isAlive() || _damageTargets.get(potentialAttacker).forgetAttackTimer.elapsed())) {
-                System.out.println("Either forgot or killed player: " + potentialPlayer.getName().getString() + " (no longer attacking)");
-                System.out.println("test: " + potentialPlayer.isAlive() + " or " + _damageTargets.get(potentialAttacker).forgetAttackTimer.elapsed());
+            if (potentialPlayer == null || (!potentialPlayer.isAlive() || _damageTargets.get(potentialAttacker).forgetAttackTimer.elapsed())) {
+                System.out.println("Either forgot or killed player: " + potentialAttacker + " (no longer attacking)");
                 _damageTargets.remove(potentialAttacker);
                 if (potentialAttacker == _currentlyAttackingPlayer) {
                     _currentlyAttackingPlayer = null;

--- a/src/main/java/adris/altoclef/chains/PlayerDefenseChain.java
+++ b/src/main/java/adris/altoclef/chains/PlayerDefenseChain.java
@@ -1,0 +1,132 @@
+package adris.altoclef.chains;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.Optional;
+
+import adris.altoclef.AltoClef;
+import adris.altoclef.eventbus.EventBus;
+import adris.altoclef.eventbus.events.PlayerDamageEvent;
+import adris.altoclef.tasksystem.TaskRunner;
+import adris.altoclef.util.time.TimerGame;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.player.PlayerEntity;
+import adris.altoclef.tasks.entity.KillPlayerTask;
+
+// TODO: Get attack events, if another player then consider attacking them for a period of time
+public class PlayerDefenseChain extends SingleTaskChain {
+
+    private Map<String, DamageTarget> _damageTargets = new HashMap<>();
+
+    private String _currentlyAttackingPlayer = null;
+
+    // TODO: CONFIG
+    private static int HITS_BEFORE_RETALIATION = 3;
+
+    public PlayerDefenseChain(TaskRunner runner) {
+        super(runner);
+        EventBus.subscribe(PlayerDamageEvent.class, evt -> onPlayerDamage(evt.source));
+    }
+
+    private void onPlayerDamage(DamageSource source) {
+        // TODO: Process and target player
+        Entity damagedBy = source.getSource();
+        if (damagedBy == null) {
+            System.out.println("ASDF null");
+        }
+        if (damagedBy instanceof PlayerEntity player) {
+            String offendingName = player.getName().getString();
+
+            if (!_damageTargets.containsKey(offendingName)) {
+                _damageTargets.put(offendingName, new DamageTarget());
+            }
+            DamageTarget target = _damageTargets.get(offendingName);
+            // Check if timed out
+            if (target.forgetInstigationTimer.elapsed()) {
+                target.timesHit = 0;
+            }
+            target.forgetInstigationTimer.reset();
+            if (!target.attacking) {
+                target.timesHit++;
+                System.out.println("Another player hit us " + target.timesHit + "times: " + offendingName + ", attacking if they hit us " + (HITS_BEFORE_RETALIATION - target.timesHit) + " more time(s).");
+                if (target.timesHit >= HITS_BEFORE_RETALIATION) {
+                    System.out.println("Too many attacks from another player! Retaliating attacks against offending player: " + offendingName);
+                    target.attacking = true;
+                    target.forgetAttackTimer.reset();
+                    // Always attack the most recently attacked entity, to keep things simple
+                    _currentlyAttackingPlayer = offendingName;
+                }
+            } else {
+                // we're already attacking, reset the chase timer since we got hit again
+                target.forgetAttackTimer.reset();
+            }
+        }
+    }
+
+    @Override
+    public float getPriority() {
+        if (_currentlyAttackingPlayer != null) {
+            Optional<PlayerEntity> currentPlayerEntity = AltoClef.getInstance().getEntityTracker().getPlayerEntity(_currentlyAttackingPlayer);
+            // dead trigger: we're done
+            if (!currentPlayerEntity.isPresent() || !currentPlayerEntity.get().isAlive()) {
+                _currentlyAttackingPlayer = null;
+            }
+        }
+        // dead OR forgot triggers for other entities: done
+        String[] playerNames = _damageTargets.keySet().toArray(String[]::new);
+        for (String potentialAttacker : playerNames) {
+            if (potentialAttacker == null) {
+                _damageTargets.remove(potentialAttacker);
+                continue;
+            }
+
+            PlayerEntity potentialPlayer = AltoClef.getInstance().getEntityTracker().getPlayerEntity(potentialAttacker).orElse(null);
+
+            if (potentialPlayer != null && (!potentialPlayer.isAlive() || _damageTargets.get(potentialAttacker).forgetAttackTimer.elapsed())) {
+                System.out.println("Either forgot or killed player: " + potentialPlayer.getName().getString() + " (no longer attacking)");
+                System.out.println("test: " + potentialPlayer.isAlive() + " or " + _damageTargets.get(potentialAttacker).forgetAttackTimer.elapsed());
+                _damageTargets.remove(potentialAttacker);
+                if (potentialAttacker == _currentlyAttackingPlayer) {
+                    _currentlyAttackingPlayer = null;
+                }
+            }
+        }
+
+        if (_currentlyAttackingPlayer != null) {
+            setTask(new KillPlayerTask(_currentlyAttackingPlayer));
+            return 55;
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean isActive() {
+        // We're always checking for player attacks
+        return true;
+    }
+
+    @Override
+    protected void onTaskFinish(AltoClef mod) {
+        // Task is done, so I guess we move on?
+    }
+
+    @Override
+    public String getName() {
+        return "Player Defense";
+    }
+
+    static class DamageTarget {
+        public TimerGame forgetInstigationTimer = new TimerGame(6);
+        public TimerGame forgetAttackTimer = new TimerGame(30);
+        public int timesHit = 0;
+        public boolean attacking = false;
+
+        public DamageTarget() {
+            // init timers
+            forgetInstigationTimer.reset();
+            forgetAttackTimer.reset();
+        }
+    }
+}

--- a/src/main/java/adris/altoclef/eventbus/events/EntitySwungEvent.java
+++ b/src/main/java/adris/altoclef/eventbus/events/EntitySwungEvent.java
@@ -1,0 +1,11 @@
+package adris.altoclef.eventbus.events;
+
+import net.minecraft.entity.Entity;
+
+public class EntitySwungEvent {
+    public Entity entity;
+
+    public EntitySwungEvent(Entity entity) {
+        this.entity = entity;
+    }
+}

--- a/src/main/java/adris/altoclef/eventbus/events/PlayerDamageEvent.java
+++ b/src/main/java/adris/altoclef/eventbus/events/PlayerDamageEvent.java
@@ -1,0 +1,14 @@
+package adris.altoclef.eventbus.events;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.damage.DamageSource;
+
+public class PlayerDamageEvent {
+    public DamageSource source;
+    public float damage;
+
+    public PlayerDamageEvent(DamageSource source, float damage) {
+        this.source = source;
+        this.damage = damage;
+    }
+}

--- a/src/main/java/adris/altoclef/mixins/EntityAnimationSwungMixin.java
+++ b/src/main/java/adris/altoclef/mixins/EntityAnimationSwungMixin.java
@@ -1,0 +1,36 @@
+package adris.altoclef.mixins;
+
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.EntityAnimationS2CPacket;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import adris.altoclef.eventbus.EventBus;
+import adris.altoclef.eventbus.events.EntitySwungEvent;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.entity.Entity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientPlayNetworkHandler.class)
+public abstract class EntityAnimationSwungMixin {
+
+    @Inject(method = "onEntityAnimation", at = @At("HEAD"))
+    private void onEntityAnimation(EntityAnimationS2CPacket packet, CallbackInfo ci) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        Entity entity = client.world.getEntityById(packet.getEntityId());
+
+        if (entity == null) {
+            return;
+        }
+
+        int id = packet.getAnimationId();
+        if (id == EntityAnimationS2CPacket.SWING_MAIN_HAND || id == EntityAnimationS2CPacket.SWING_OFF_HAND) {
+            // System.out.println("[Mixin] " + entity.getName().getString() + " swung main hand.");
+            EventBus.publish(new EntitySwungEvent(entity));
+        }
+    }
+}

--- a/src/main/java/adris/altoclef/mixins/PlayerDamageMixin.java
+++ b/src/main/java/adris/altoclef/mixins/PlayerDamageMixin.java
@@ -1,0 +1,27 @@
+package adris.altoclef.mixins;
+
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.text.Text;
+
+import adris.altoclef.eventbus.EventBus;
+import adris.altoclef.eventbus.events.PlayerDamageEvent;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientPlayerEntity.class)
+public class PlayerDamageMixin {
+    
+    @Inject(
+        method = "damage",
+        at = @At("HEAD")
+    )
+    public void getDamaged(DamageSource source, float amount, CallbackInfoReturnable<Boolean> ci) {
+        System.out.println("WE GOT DAMAGED!");
+        EventBus.publish(new PlayerDamageEvent(source, amount));
+    }
+}

--- a/src/main/java/adris/altoclef/mixins/PlayerDamageMixin.java
+++ b/src/main/java/adris/altoclef/mixins/PlayerDamageMixin.java
@@ -12,21 +12,23 @@ import adris.altoclef.eventbus.events.PlayerDamageEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(PlayerEntity.class)
+@Mixin(ClientPlayerEntity.class)
 public class PlayerDamageMixin {
     
     @Inject(
         method = "damage",
         at = @At("HEAD")
     )
-    public void getDamaged(DamageSource source, float amount, CallbackInfoReturnable<Boolean> ci) {
-        PlayerEntity p = (PlayerEntity) ((Object)this);
-        if ( !(p.getName().equals(MinecraftClient.getInstance().player.getName())) ) {
-            // must be the client player
-            return;
-        }
+    public void applyDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> ci) {
+        // System.out.println("DAMAGED: " + source.getAttacker() + " " + source.getName());
+        // PlayerEntity p = (PlayerEntity) ((Object)this);
+        // if ( !(p.getName().equals(MinecraftClient.getInstance().player.getName())) ) {
+        //     // must be the client player
+        //     return;
+        // }
         EventBus.publish(new PlayerDamageEvent(source, amount));
     }
 }

--- a/src/main/java/adris/altoclef/mixins/PlayerDamageMixin.java
+++ b/src/main/java/adris/altoclef/mixins/PlayerDamageMixin.java
@@ -1,7 +1,8 @@
 package adris.altoclef.mixins;
 
-import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.Text;
 
@@ -13,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(ClientPlayerEntity.class)
+@Mixin(PlayerEntity.class)
 public class PlayerDamageMixin {
     
     @Inject(
@@ -21,7 +22,11 @@ public class PlayerDamageMixin {
         at = @At("HEAD")
     )
     public void getDamaged(DamageSource source, float amount, CallbackInfoReturnable<Boolean> ci) {
-        System.out.println("WE GOT DAMAGED!");
+        PlayerEntity p = (PlayerEntity) ((Object)this);
+        if ( !(p.getName().equals(MinecraftClient.getInstance().player.getName())) ) {
+            // must be the client player
+            return;
+        }
         EventBus.publish(new PlayerDamageEvent(source, amount));
     }
 }

--- a/src/main/java/adris/altoclef/tasks/entity/KillPlayerTask.java
+++ b/src/main/java/adris/altoclef/tasks/entity/KillPlayerTask.java
@@ -1,0 +1,55 @@
+package adris.altoclef.tasks.entity;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import adris.altoclef.AltoClef;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+
+public class KillPlayerTask extends AbstractKillEntityTask {
+
+    private String playerName;
+
+    public KillPlayerTask(String playerName) {
+        this.playerName = playerName;
+    }
+
+    public KillPlayerTask(String playerName, double maintainDistance, double combatGuardLowerRange, double combatGuardLowerFieldRadius) {
+        super(maintainDistance, combatGuardLowerRange, combatGuardLowerFieldRadius);
+        this.playerName = playerName;
+    }
+
+    @Override
+    protected Optional<Entity> getEntityTarget(AltoClef mod) {
+
+        for (Entity entity : MinecraftClient.getInstance().world.getEntities()) {
+            if (entity instanceof PlayerEntity) {
+                String playerName = entity.getName().getString().toLowerCase();
+                // System.out.println("GOT PLAYER ENTITY: " + playerName);
+                if (playerName != null && playerName.equals(this.playerName.toLowerCase())) {
+                    // System.out.println("YAH: " + playerName + " == " + this.playerName.toLowerCase());
+                    return Optional.of(entity);
+                }
+                // System.out.println("nah: " + playerName);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    protected boolean isSubEqual(AbstractDoToEntityTask other) {
+        if (other instanceof KillPlayerTask task) {
+            return Objects.equals(task.playerName, playerName);
+        }
+        return false;
+    }
+
+    @Override
+    protected String toDebugString() {
+        return "Killing Player " + playerName;
+    }
+}

--- a/src/main/java/adris/altoclef/util/helpers/LookHelper.java
+++ b/src/main/java/adris/altoclef/util/helpers/LookHelper.java
@@ -523,6 +523,22 @@ public interface LookHelper {
         return mod.getClientBaritone().getPlayerContext().isLookingAt(pos);
     }
 
+    static boolean isLookingAt(Entity entity, Vec3d toLookAt, double angleThreshold) {
+        Vec3d head = entity.getPos().add(new Vec3d(0, entity.getStandingEyeHeight(), 0));
+        Rotation rotation = new Rotation(entity.getYaw(), entity.getPitch());
+
+        Vec3d look = RotationUtils.calcLookDirectionFromRotation(rotation);
+
+        Vec3d targetLook = toLookAt.subtract(head).normalize();
+
+        double dot = look.dotProduct(targetLook);
+        double angle = Math.toDegrees(Math.acos(dot));
+
+        // System.out.println("ANGLE: " + angle);
+
+        return Math.abs(angle) < angleThreshold;
+    }
+
     /**
      * Updates the player's look direction and rotation.
      *

--- a/src/main/resources/altoclef.mixins.json
+++ b/src/main/resources/altoclef.mixins.json
@@ -14,6 +14,7 @@
     "DeathScreenAccessor",
     "EntityAccessor",
     "GameOverlayMixin",
+    "PlayerDamageMixin",
     "MiningToolItemAccessor",
     "MovementHelperMixin",
     "PersistentProjectileEntityAccessor",

--- a/src/main/resources/altoclef.mixins.json
+++ b/src/main/resources/altoclef.mixins.json
@@ -37,7 +37,7 @@
     "SimpleOptionMixin",
     "EntityAnimationSwungMixin",
     "MobDeathMixin"
-]  ],
+  ],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/altoclef.mixins.json
+++ b/src/main/resources/altoclef.mixins.json
@@ -14,7 +14,6 @@
     "DeathScreenAccessor",
     "EntityAccessor",
     "GameOverlayMixin",
-    "PlayerDamageMixin",
     "MiningToolItemAccessor",
     "MovementHelperMixin",
     "PersistentProjectileEntityAccessor",
@@ -34,7 +33,9 @@
     "LoadChunkMixin",
     "MixinLocalPlayer",
     "PlayerCollidesWithEntityMixin",
-    "SimpleOptionMixin"
+    "PlayerDamageMixin",
+    "SimpleOptionMixin",
+    "EntityAnimationSwungMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
### Add player defense mechanism to retaliate after 3 hits from attacking players
Implements a player defense system through a new task chain architecture:

* Adds new `PlayerDefenseChain` that monitors and retaliates against players who attack the bot after 3 hits, with a 6-second inactivity timeout and 30-second attack timeout in [PlayerDefenseChain.java](https://github.com/elefant-ai/chatclef/pull/23/files#diff-f1d5eaf9f6d9430f38bc372993dd6196cbf0f55426f08c6f9c27c4442435ab3b)
* Creates `KillPlayerTask` for targeting specific players by name in [KillPlayerTask.java](https://github.com/elefant-ai/chatclef/pull/23/files#diff-17ef826c2fb942de9d4d7726deacc755b738a19bc4b37a43b54806588dc1337d)
* Implements damage event system with `PlayerDamageEvent` and `PlayerDamageMixin` to detect player attacks in [PlayerDamageMixin.java](https://github.com/elefant-ai/chatclef/pull/23/files#diff-5f61525741f4aa4bf8e54b17e8401be3ab62c5cc9c92cd77f2787e4789822f95)
* Integrates defense chain initialization in `AltoClef` class alongside existing chains in [AltoClef.java](https://github.com/elefant-ai/chatclef/pull/23/files#diff-d367ff97b960553c1363b112e7e24e8135753dacd064485925543550cbb31be8)

#### 📍Where to Start
Start with the initialization of the defense chain in the `AltoClef` class at [AltoClef.java](https://github.com/elefant-ai/chatclef/pull/23/files#diff-d367ff97b960553c1363b112e7e24e8135753dacd064485925543550cbb31be8), then follow the implementation in [PlayerDefenseChain.java](https://github.com/elefant-ai/chatclef/pull/23/files#diff-f1d5eaf9f6d9430f38bc372993dd6196cbf0f55426f08c6f9c27c4442435ab3b)



#### Changes since #23 opened

- Modified player defense retaliation logic in `adris.altoclef` chains [649c1ad]
- Reworked mob defense distance calculations in `adris.altoclef` chains [649c1ad]
- Refined projectile avoidance system in `adris.altoclef` chains [649c1ad]
----

_[Macroscope](https://app.macroscope.com) summarized 649c1ad._