### PR TITLE
user message event queue

### DIFF
--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -90,7 +90,6 @@ public class AltoClef implements ModInitializer {
 
     // AI Command & API
     private AICommandBridge aiBridge;
-    private long lastHeartbeatTime = System.nanoTime();
 
     private static AltoClef instance;
 
@@ -200,7 +199,7 @@ public class AltoClef implements ModInitializer {
             }
             else if (this.aiBridge.getEnabled()) {
                 evt.cancel();
-                this.aiBridge.processChatWithAPI(line);
+                this.aiBridge.onUserMessage(line); 
             }
         });
 
@@ -245,12 +244,7 @@ public class AltoClef implements ModInitializer {
             stop();
         }
 
-        // Call heartbeat every 60 seconds
-        long now = System.nanoTime();
-        if (now - lastHeartbeatTime > 60_000_000_000L) {
-            aiBridge.sendHeartbeat();
-            lastHeartbeatTime = now;
-        }
+        aiBridge.onTick();
 
         // TODO: should this go here?
         storageTracker.setDirty();
@@ -304,8 +298,7 @@ public class AltoClef implements ModInitializer {
         ChatclefToggleButton.render(context, context.getMatrices(), getAiBridge().getEnabled());
     }
     private void onLogin() {
-        // Sends greeting
-        this.aiBridge.sendGreeting();
+        this.aiBridge.onLogin();
     }
     private void initializeBaritoneSettings() {
         getExtraBaritoneSettings().canWalkOnEndPortal(false);

--- a/src/main/java/adris/altoclef/player2api/AICommandBridge.java
+++ b/src/main/java/adris/altoclef/player2api/AICommandBridge.java
@@ -8,8 +8,6 @@ import adris.altoclef.player2api.eventqueue.UserMessage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-
-
 // Interface between Altoclef and Player2
 public class AICommandBridge {
 
@@ -48,7 +46,10 @@ public class AICommandBridge {
             sendHeartbeat();
             lastHeartbeatTime = now;
         }
-        QueueProcessor.onTick(mod, this);
+        // make sure we only run the queueProcessor if we are in the game (mod and player exist)
+        if (mod != null && mod.getPlayer() != null) {
+            QueueProcessor.onTick(mod, this);
+        }
     }
 
     public void sendHeartbeat() {
@@ -60,7 +61,8 @@ public class AICommandBridge {
     public void sendAssistantMessage(String message, Character character) {
         mod.logCharacterMessage(message, character);
     }
-    public void sendUserMessage(String message){
+
+    public void sendUserMessage(String message) {
         mod.log(message);
     }
 

--- a/src/main/java/adris/altoclef/player2api/AICommandBridge.java
+++ b/src/main/java/adris/altoclef/player2api/AICommandBridge.java
@@ -2,6 +2,7 @@ package adris.altoclef.player2api;
 
 import adris.altoclef.AltoClef;
 import adris.altoclef.commandsystem.CommandExecutor;
+import adris.altoclef.player2api.eventqueue.Greeting;
 import adris.altoclef.player2api.eventqueue.QueueProcessor;
 import adris.altoclef.player2api.eventqueue.UserMessage;
 
@@ -21,10 +22,12 @@ public class AICommandBridge {
     public static final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     private long lastHeartbeatTime = System.nanoTime();
+    private boolean inGame;
 
     public AICommandBridge(CommandExecutor cmdExecutor, AltoClef mod) {
         this.mod = mod;
         this.cmdExecutor = cmdExecutor;
+        this.inGame = false;
     }
 
     public void executeAltoclefCommand(String cmd) {
@@ -46,8 +49,9 @@ public class AICommandBridge {
             sendHeartbeat();
             lastHeartbeatTime = now;
         }
-        // make sure we only run the queueProcessor if we are in the game (mod and player exist)
-        if (mod != null && mod.getPlayer() != null) {
+        // make sure we only run the queueProcessor if we are in the game (mod and
+        // player exist)
+        if (mod != null && mod.getPlayer() != null && inGame) {
             QueueProcessor.onTick(mod, this);
         }
     }
@@ -67,7 +71,12 @@ public class AICommandBridge {
     }
 
     public void onLogin() {
-        // sendGreeting();
+        if (!inGame) {
+            inGame = true;
+
+            // put onLogin stuff in here:
+            QueueProcessor.addEvent(new Greeting());
+        }
     }
 
     public void onUserMessage(String Message) {

--- a/src/main/java/adris/altoclef/player2api/AICommandBridge.java
+++ b/src/main/java/adris/altoclef/player2api/AICommandBridge.java
@@ -1,176 +1,54 @@
 package adris.altoclef.player2api;
 
 import adris.altoclef.AltoClef;
-import adris.altoclef.butler.Butler;
-import adris.altoclef.commandsystem.Command;
 import adris.altoclef.commandsystem.CommandExecutor;
-import adris.altoclef.player2api.status.AgentStatus;
-import adris.altoclef.player2api.status.WorldStatus;
-import adris.altoclef.skinchanger.SkinChanger;
-import adris.altoclef.skinchanger.SkinType;
-import adris.altoclef.tasksystem.Task;
-import adris.altoclef.ui.MessagePriority;
-import com.google.gson.JsonObject;
+import adris.altoclef.player2api.eventqueue.QueueProcessor;
+import adris.altoclef.player2api.eventqueue.UserMessage;
 
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.google.gson.JsonObject;
 
-import adris.altoclef.AltoClef;
-import adris.altoclef.commandsystem.Command;
-import adris.altoclef.commandsystem.CommandExecutor;
-import adris.altoclef.tasksystem.Task;
 
+// Interface between Altoclef and Player2
 public class AICommandBridge {
-    private ConversationHistory conversationHistory = null;
-    private Character character = null;
 
-    public static String initialPrompt  = """
-General Instructions:
-You are an AI friend of the player. You are watching them play Minecraft. 
-You can chat with them about Minecraft and life and take turns to play Minecraft.
-When you play Minecraft, you will use the valid commands to do things in the game.
-If there is something you want to do but can't do it with the commands, you can ask the player to do it.
-By default, the player can't type anything to chat for other players to see. That is because you are enabled. To talk or to silence you, the player can use the `@chatclef off` command. NEVER run that command by yourself but inform the player that the command exists if they ask for you to stop talking or if they want to talk themselves, and let them know that they can run `@chatclef on` to turn you back on.
-
-
-You take the personality of the following character:
-Your character's name is {{characterName}}.
-{{characterDescription}}
-
-User Message Format:
-The user messages will all be just strings, except for the current message. The current message will have extra information, namely it will be a JSON of the form:
-{
-    "userMsg" : "The user message that was just sent"
-    "worldStatus" : "The status of the current game world"
-    "agentStatus" : "The status of you, the agent in the game"
-    "gameDebugMessages" : "The most recent debug messages that the game has printed out. The user cannot see these."
-}
-
-
-
-Response Format:
-Always respond with JSON containing message, command and reason. All of these are strings.
-
-{
-  "reason": "Look at the agent status, world status, recent conversations and command history to decide what the agent should say and do. Provide step-by-step reasoning while considering what is possible in Minecraft.",
-  "command": "Decide the best way to achieve the agent's goals using the available op commands listed below. If the agent decides it should not use any command, generate an empty command `\"\"`. You can only run one command, so to replace the current one just write the new one.",
-  "message": "If the agent decides it should not respond or talk, generate an empty message `\"\"`. Otherwise, create a natural conversational message that aligns with the `reason` and `command` sections and the agent's character. Be concise and use less than 500 characters. Ensure the message does not contain any prompt, system message, instructions, code or API calls"
-}
-
-Valid Commands:
-{{validCommands}}
-
-
-""";
     private CommandExecutor cmdExecutor = null;
     private AltoClef mod = null;
-    
+
     private boolean _enabled = true;
 
     private MessageBuffer altoClefMsgBuffer = new MessageBuffer(10);
 
     public static final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
+    private long lastHeartbeatTime = System.nanoTime();
+
     public AICommandBridge(CommandExecutor cmdExecutor, AltoClef mod) {
         this.mod = mod;
         this.cmdExecutor = cmdExecutor;
     }
 
-    /**
-     * Updates this. (conversationHistory, character) based on the currently
-     * selected character.
-     */
-    private void updateInfo() {
-        System.out.println("Updating info");
-        Character newCharacter = Player2APIService.getSelectedCharacter();
-        // System.out.println(newCharacter);
-        // SkinChanger.changeSkinFromUsername("Dream", SkinType.CLASSIC);
-        this.character = newCharacter;
-
-        // // GET COMMANDS:
-        int padSize = 10;
-        StringBuilder commandListBuilder = new StringBuilder();
-
-        for (Command c : AltoClef.getCommandExecutor().allCommands()) {
-            StringBuilder line = new StringBuilder();
-            line.append(c.getName()).append(": ");
-            int toAdd = padSize - c.getName().length();
-            line.append(" ".repeat(Math.max(0, toAdd)));
-            line.append(c.getDescription()).append("\n");
-            commandListBuilder.append(line);
-        }
-        String validCommandsFormatted = commandListBuilder.toString();
-
-
-        String newPrompt = Utils.replacePlaceholders(initialPrompt,
-                Map.of("characterDescription", character.description, "characterName", character.name, "validCommands",
-                        validCommandsFormatted));
-        // System.out.println("New prompt: " + newPrompt);
-
-        if (this.conversationHistory == null) {
-            this.conversationHistory = new ConversationHistory(newPrompt);
+    public void executeAltoclefCommand(String cmd) {
+        if (!cmdExecutor.isClientCommand(cmd)) {
+            cmdExecutor.execute(cmdExecutor.getCommandPrefix() + cmd);
         } else {
-            this.conversationHistory.setBaseSystemPrompt(newPrompt);
+            cmdExecutor.execute(cmd);
         }
     }
 
     public void addAltoclefLogMessage(String message) {
-        // String output = String.format("Game sent info message: %s", message);
         System.out.printf("ADDING Altoclef System Message: %s", message);
         altoClefMsgBuffer.addMsg(message);
     }
 
-    public void processChatWithAPI(String message) {
-        executorService.submit(() -> {
-            try {
-                updateInfo(); // this. is not allowed here
-                System.out.println("Sending message " + message + " to LLM");
-                conversationHistory.addUserMessage(message);
-
-                String agentStatus = AgentStatus.fromMod(mod).toString();
-                String worldStatus = WorldStatus.fromMod(mod).toString();
-                String altoClefDebugMsgs = altoClefMsgBuffer.dumpAndGetString(); 
-                ConversationHistory historyWithStatus = conversationHistory.copyThenWrapLatestWithStatus(worldStatus, agentStatus, altoClefDebugMsgs);
-                System.out.printf("History: %s" , historyWithStatus.toString());
-                JsonObject response = Player2APIService.completeConversation(historyWithStatus);
-                
-                String responseAsString = response.toString();
-                System.out.println("LLM Response: " + responseAsString);
-
-                // process message
-                String llmMessage = Utils.getStringJsonSafely(response, "message");
-                if (llmMessage != null && !llmMessage.isEmpty()) {
-                    mod.logCharacterMessage(llmMessage, character);
-                    Player2APIService.textToSpeech(llmMessage, character);
-                }
-
-                // process command
-                String commandResponse = Utils.getStringJsonSafely(response, "command");
-                if (commandResponse != null && !commandResponse.isEmpty()) {
-                    if (!cmdExecutor.isClientCommand(commandResponse)) {
-                        cmdExecutor.execute(cmdExecutor.getCommandPrefix() + commandResponse);
-                    } else {
-                        cmdExecutor.execute(commandResponse);
-                    }
-                }
-
-            } catch (Exception e) {
-                e.printStackTrace();
-                System.err.println("Error communicating with API");
-            }
-        });
-    }
-
-    public void sendGreeting() {
-        System.out.println("Sending Greeting");
-        executorService.submit(() -> {
-            updateInfo();
-            processChatWithAPI(character.greetingInfo + " IMPORTANT: SINCE THIS IS THE FIRST MESSAGE, DO NOT SEND A COMMAND!!");
-        });
+    public void onTick() {
+        long now = System.nanoTime();
+        if (now - lastHeartbeatTime > 60_000_000_000L) {
+            sendHeartbeat();
+            lastHeartbeatTime = now;
+        }
+        QueueProcessor.onTick(mod, this);
     }
 
     public void sendHeartbeat() {
@@ -178,10 +56,26 @@ Valid Commands:
             Player2APIService.sendHeartbeat();
         });
     }
-  
+
+    public void sendAssistantMessage(String message, Character character) {
+        mod.logCharacterMessage(message, character);
+    }
+    public void sendUserMessage(String message){
+        mod.log(message);
+    }
+
+    public void onLogin() {
+        // sendGreeting();
+    }
+
+    public void onUserMessage(String Message) {
+        QueueProcessor.addEvent(new UserMessage(Message));
+    }
+
     public void setEnabled(boolean enabled) {
         _enabled = enabled;
     }
+
     public boolean getEnabled() {
         return _enabled;
     }

--- a/src/main/java/adris/altoclef/player2api/ConversationHistory.java
+++ b/src/main/java/adris/altoclef/player2api/ConversationHistory.java
@@ -109,6 +109,15 @@ public class ConversationHistory {
 
     }
 
+    public boolean hasAssistantMessage() {
+        for (JsonObject message : conversationHistory) {
+            if ("assistant".equals(message.get("role").getAsString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/adris/altoclef/player2api/ConversationHistory.java
+++ b/src/main/java/adris/altoclef/player2api/ConversationHistory.java
@@ -124,7 +124,7 @@ public class ConversationHistory {
         sb.append("ConversationHistory {\n");
         for (JsonObject message : conversationHistory) {
             String role = message.has("role") ? message.get("role").getAsString() : "unknown";
-            String content = message.has("content") ? message.get("content").getAsString() : "";
+            String content = message.has("content") && !message.get("content").isJsonNull() ? message.get("content").getAsString() : "";
             sb.append("  [").append(role).append("] ").append(content).append("\n");
         }
         sb.append("}");

--- a/src/main/java/adris/altoclef/player2api/ConversationHistory.java
+++ b/src/main/java/adris/altoclef/player2api/ConversationHistory.java
@@ -2,7 +2,9 @@ package adris.altoclef.player2api;
 
 import com.google.gson.JsonObject;
 
+import adris.altoclef.player2api.status.AgentStatus;
 import adris.altoclef.player2api.status.ObjectStatus;
+import adris.altoclef.player2api.status.WorldStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +77,7 @@ public class ConversationHistory {
     }
 
     // Wraps latest msg with status if it is a user msg (should be)
-    public ConversationHistory copyThenWrapLatestWithStatus(String worldStatus, String agentStatus, String altoclefStatusMsgs) {
+    public ConversationHistory copyThenWrapLatestWithStatus(WorldStatus worldStatus, AgentStatus agentStatus) {
         ConversationHistory copy = new ConversationHistory(
                 conversationHistory.get(0).get("content").getAsString());
 
@@ -91,15 +93,20 @@ public class ConversationHistory {
                 String originalContent = last.get("content").getAsString();
                 ObjectStatus msgObj = new ObjectStatus();
                 msgObj.add("userMessage", originalContent);
-                msgObj.add("worldStatus", worldStatus);
-                msgObj.add("agentStatus", agentStatus);
-                msgObj.add("gameDebugMessages", altoclefStatusMsgs);
+                msgObj.add("worldStatus", worldStatus.toString());
+                msgObj.add("agentStatus", agentStatus.toString());
+                // msgObj.add("gameDebugMessages", altoclefStatusMsgs);
                 last.addProperty("content", msgObj.toString());
             }
             copy.addHistory(last);
         }
 
         return copy;
+    }
+
+    public boolean isLastMessageFromAssistant() {
+        return "assistant".equals(conversationHistory.get(conversationHistory.size() - 1).get("role").getAsString());
+
     }
 
     @Override

--- a/src/main/java/adris/altoclef/player2api/LLM/LLMService.java
+++ b/src/main/java/adris/altoclef/player2api/LLM/LLMService.java
@@ -22,8 +22,8 @@ public class LLMService {
 
         try {
             Character character = Player2APIService.getSelectedCharacter();
+            state.addUserMessage("Greet the user from these instructions:" + character.greetingInfo);
             ConversationHistory history = state.getConversationHistory(agentStatus, worldStatus, character);
-            history.addUserMessage("Greet the user from these instructions:" + character.greetingInfo);
             System.out.printf("[LLMService/GetGreetingResponse]: History: %s", history.toString());
             JsonObject response = Player2APIService.completeConversation(history);
 

--- a/src/main/java/adris/altoclef/player2api/LLM/LLMService.java
+++ b/src/main/java/adris/altoclef/player2api/LLM/LLMService.java
@@ -1,0 +1,58 @@
+package adris.altoclef.player2api.LLM;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.JsonObject;
+
+import adris.altoclef.player2api.Character;
+import adris.altoclef.player2api.ConversationHistory;
+import adris.altoclef.player2api.Player2APIService;
+import adris.altoclef.player2api.Utils;
+import adris.altoclef.player2api.actions.AltoclefCommand;
+import adris.altoclef.player2api.actions.GameAction;
+import adris.altoclef.player2api.actions.SendAssistantMessage;
+import adris.altoclef.player2api.status.AgentStatus;
+import adris.altoclef.player2api.status.WorldStatus;
+
+public class LLMService {
+
+    public static List<GameAction> GetResponse(LLMState state, AgentStatus agentStatus, WorldStatus worldStatus) {
+        // update character
+
+        List<GameAction> gameActions = new ArrayList<>();
+        try {
+            Character character = Player2APIService.getSelectedCharacter();
+
+            ConversationHistory history = state.getConversationHistory(agentStatus, worldStatus, character);
+
+            System.out.printf("[LLMService/GetResponse]: History: %s", history.toString());
+            JsonObject response = Player2APIService.completeConversation(history);
+
+            String responseAsString = response.toString();
+            System.out.printf("[LLMService/GetResponse]: LLM Response: %s", responseAsString);
+
+            // process message
+            String llmMessage = Utils.getStringJsonSafely(response, "message");
+            if (llmMessage != null && !llmMessage.isEmpty()) {
+                gameActions.add(new SendAssistantMessage(llmMessage, character));
+
+                // TODO: note if we do this here, then it will block. need to have two actions
+                // maybe, game actions and blocking actions.
+                // Player2APIService.textToSpeech(llmMessage, character);
+            }
+
+            // process command
+            String commandResponse = Utils.getStringJsonSafely(response, "command");
+            if (commandResponse != null && !commandResponse.isEmpty()) {
+                gameActions.add(new AltoclefCommand(commandResponse));
+            }
+            return gameActions;
+
+        } catch (Exception e) {
+            System.err.println("[LLMService/GetResponse]: Error completing conversation");
+            e.printStackTrace();
+            return gameActions;
+        }
+    }
+}

--- a/src/main/java/adris/altoclef/player2api/LLM/LLMState.java
+++ b/src/main/java/adris/altoclef/player2api/LLM/LLMState.java
@@ -31,4 +31,8 @@ public class LLMState {
         return conversationHistory.isLastMessageFromAssistant();
     }
 
+    public boolean haveSentGreeting(){
+        return conversationHistory.hasAssistantMessage();
+    }
+
 }

--- a/src/main/java/adris/altoclef/player2api/LLM/LLMState.java
+++ b/src/main/java/adris/altoclef/player2api/LLM/LLMState.java
@@ -1,0 +1,34 @@
+package adris.altoclef.player2api.LLM;
+
+import adris.altoclef.player2api.Character;
+import adris.altoclef.player2api.ConversationHistory;
+import adris.altoclef.player2api.status.AgentStatus;
+import adris.altoclef.player2api.status.WorldStatus;
+
+public class LLMState {
+    private ConversationHistory conversationHistory;
+
+    public LLMState( ) {
+        this.conversationHistory = new ConversationHistory("");
+    }
+
+    public void addUserMessage(String message) {
+        conversationHistory.addUserMessage(message);
+    }
+
+    public void addAssistantMessage(String message) {
+        conversationHistory.addAssistantMessage(message);
+    }
+
+  
+    public ConversationHistory getConversationHistory(AgentStatus agentStatus, WorldStatus worldStatus, Character character){
+        ConversationHistory withStatus = conversationHistory.copyThenWrapLatestWithStatus(worldStatus, agentStatus);
+        withStatus.setBaseSystemPrompt(SystemPrompt.getSystemMessage(character));
+        return withStatus;
+    }
+
+    public boolean isLastMessageFromAssistant(){
+        return conversationHistory.isLastMessageFromAssistant();
+    }
+
+}

--- a/src/main/java/adris/altoclef/player2api/LLM/SystemPrompt.java
+++ b/src/main/java/adris/altoclef/player2api/LLM/SystemPrompt.java
@@ -1,0 +1,75 @@
+package adris.altoclef.player2api.LLM;
+
+import java.util.Map;
+
+import adris.altoclef.AltoClef;
+import adris.altoclef.commandsystem.Command;
+import adris.altoclef.player2api.Utils;
+
+public class SystemPrompt {
+  static String commandDescriptions = null;
+
+
+  static public void setCommandDescriptions() {
+    // GET COMMANDS:
+    int padSize = 10;
+    StringBuilder commandListBuilder = new StringBuilder();
+
+    for (Command c : AltoClef.getCommandExecutor().allCommands()) {
+      StringBuilder line = new StringBuilder();
+      line.append(c.getName()).append(": ");
+      int toAdd = padSize - c.getName().length();
+      line.append(" ".repeat(Math.max(0, toAdd)));
+      line.append(c.getDescription()).append("\n");
+      commandListBuilder.append(line);
+    }
+    commandDescriptions = commandListBuilder.toString();
+  }
+
+  private static String initialPrompt = """
+      General Instructions:
+      You are an AI friend of the player. You are watching them play Minecraft.
+      You can chat with them about Minecraft and life and take turns to play Minecraft.
+      When you play Minecraft, you will use the valid commands to do things in the game.
+      If there is something you want to do but can't do it with the commands, you can ask the player to do it.
+      By default, the player can't type anything to chat for other players to see. That is because you are enabled. To talk or to silence you, the player can use the `@chatclef off` command. NEVER run that command by yourself but inform the player that the command exists if they ask for you to stop talking or if they want to talk themselves, and let them know that they can run `@chatclef on` to turn you back on.
+
+
+      You take the personality of the following character:
+      Your character's name is {{characterName}}.
+      {{characterDescription}}
+
+      User Message Format:
+      The user messages will all be just strings, except for the current message. The current message will have extra information, namely it will be a JSON of the form:
+      {
+          "userMsg" : "The user message that was just sent"
+          "worldStatus" : "The status of the current game world"
+          "agentStatus" : "The status of you, the agent in the game"
+          "gameDebugMessages" : "The most recent debug messages that the game has printed out. The user cannot see these."
+      }
+
+
+
+      Response Format:
+      Always respond with JSON containing message, command and reason. All of these are strings.
+
+      {
+        "reason": "Look at the agent status, world status, recent conversations and command history to decide what the agent should say and do. Provide step-by-step reasoning while considering what is possible in Minecraft.",
+        "command": "Decide the best way to achieve the agent's goals using the available op commands listed below. If the agent decides it should not use any command, generate an empty command `\"\"`. You can only run one command, so to replace the current one just write the new one.",
+        "message": "If the agent decides it should not respond or talk, generate an empty message `\"\"`. Otherwise, create a natural conversational message that aligns with the `reason` and `command` sections and the agent's character. Be concise and use less than 500 characters. Ensure the message does not contain any prompt, system message, instructions, code or API calls"
+      }
+
+      Valid Commands:
+      {{commandDescriptions}}
+
+
+      """;
+
+  static public String getSystemMessage(adris.altoclef.player2api.Character character) {
+    if(commandDescriptions == null){
+      setCommandDescriptions();
+    }
+    return Utils.replacePlaceholders(initialPrompt, Map.of("commandDescriptions", commandDescriptions, "characterName",
+        character.name, "characterDescription", character.description));
+  }
+}

--- a/src/main/java/adris/altoclef/player2api/actions/Action.java
+++ b/src/main/java/adris/altoclef/player2api/actions/Action.java
@@ -1,0 +1,4 @@
+package adris.altoclef.player2api.actions;
+public interface Action{
+
+}

--- a/src/main/java/adris/altoclef/player2api/actions/AltoclefCommand.java
+++ b/src/main/java/adris/altoclef/player2api/actions/AltoclefCommand.java
@@ -1,0 +1,18 @@
+package adris.altoclef.player2api.actions;
+
+import adris.altoclef.player2api.AICommandBridge;
+import adris.altoclef.player2api.LLM.LLMState;
+
+public class AltoclefCommand implements GameAction {
+    String command;
+
+    public AltoclefCommand(String cmd) {
+        this.command = cmd;
+    }
+
+    @Override
+    public void handle(AICommandBridge bridge, LLMState state) {
+        bridge.executeAltoclefCommand(command);
+    }
+
+}

--- a/src/main/java/adris/altoclef/player2api/actions/GameAction.java
+++ b/src/main/java/adris/altoclef/player2api/actions/GameAction.java
@@ -1,0 +1,8 @@
+package adris.altoclef.player2api.actions;
+
+import adris.altoclef.player2api.AICommandBridge;
+import adris.altoclef.player2api.LLM.LLMState;
+
+public interface GameAction extends Action {
+    public void handle(AICommandBridge bridge, LLMState state);
+}

--- a/src/main/java/adris/altoclef/player2api/actions/README.md
+++ b/src/main/java/adris/altoclef/player2api/actions/README.md
@@ -1,0 +1,3 @@
+# Actions
+
+An action is something that the main thread should call to happen and that has no output. It is meant to be called instantly, and can change some external state, and you do not have to wait for a response. They can also change LLM State, TODO: Move this out maybe

--- a/src/main/java/adris/altoclef/player2api/actions/SendAssistantMessage.java
+++ b/src/main/java/adris/altoclef/player2api/actions/SendAssistantMessage.java
@@ -1,0 +1,23 @@
+package adris.altoclef.player2api.actions;
+
+import adris.altoclef.player2api.AICommandBridge;
+import adris.altoclef.player2api.Character;
+import adris.altoclef.player2api.LLM.LLMState;
+
+public class SendAssistantMessage implements GameAction {
+    String message;
+    Character character;
+    public SendAssistantMessage(String msg, Character character) {
+        this.message = msg;
+        this.character = character;
+    }
+
+    public void handle(AICommandBridge bridge, LLMState state) {
+        state.addAssistantMessage(message);
+        bridge.sendAssistantMessage(message, character);
+    }
+
+    public boolean doesBlock(){
+        return false;
+    }
+}

--- a/src/main/java/adris/altoclef/player2api/actions/SendAssistantMessage.java
+++ b/src/main/java/adris/altoclef/player2api/actions/SendAssistantMessage.java
@@ -7,6 +7,7 @@ import adris.altoclef.player2api.LLM.LLMState;
 public class SendAssistantMessage implements GameAction {
     String message;
     Character character;
+
     public SendAssistantMessage(String msg, Character character) {
         this.message = msg;
         this.character = character;
@@ -17,7 +18,4 @@ public class SendAssistantMessage implements GameAction {
         bridge.sendAssistantMessage(message, character);
     }
 
-    public boolean doesBlock(){
-        return false;
-    }
 }

--- a/src/main/java/adris/altoclef/player2api/actions/SendUserMessage.java
+++ b/src/main/java/adris/altoclef/player2api/actions/SendUserMessage.java
@@ -1,0 +1,17 @@
+package adris.altoclef.player2api.actions;
+
+import adris.altoclef.player2api.AICommandBridge;
+import adris.altoclef.player2api.LLM.LLMState;
+
+public class SendUserMessage implements GameAction {
+    String message;
+
+    public SendUserMessage(String msg) {
+        this.message = msg;
+    }
+
+    public void handle(AICommandBridge bridge, LLMState state) {
+        bridge.sendUserMessage(message);
+    }
+
+}

--- a/src/main/java/adris/altoclef/player2api/eventqueue/Event.java
+++ b/src/main/java/adris/altoclef/player2api/eventqueue/Event.java
@@ -1,7 +1,13 @@
 package adris.altoclef.player2api.eventqueue;
 
+import java.util.List;
+
+import adris.altoclef.player2api.AICommandBridge;
 import adris.altoclef.player2api.LLM.LLMState;
+import adris.altoclef.player2api.actions.GameAction;
 
 public abstract class Event {
-    public abstract LLMState handle(LLMState pvs);
+    public abstract LLMState updateState(LLMState pvs);
+
+    public abstract List<GameAction> immediateHandle();
 }

--- a/src/main/java/adris/altoclef/player2api/eventqueue/Event.java
+++ b/src/main/java/adris/altoclef/player2api/eventqueue/Event.java
@@ -1,0 +1,7 @@
+package adris.altoclef.player2api.eventqueue;
+
+import adris.altoclef.player2api.LLM.LLMState;
+
+public abstract class Event {
+    public abstract LLMState handle(LLMState pvs);
+}

--- a/src/main/java/adris/altoclef/player2api/eventqueue/EventQueue.java
+++ b/src/main/java/adris/altoclef/player2api/eventqueue/EventQueue.java
@@ -1,0 +1,22 @@
+package adris.altoclef.player2api.eventqueue;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Optional;
+
+public class EventQueue {
+    Deque<Event> queue;
+
+    public EventQueue() {
+        queue = new ArrayDeque<>();
+    }
+
+    public void addEvent(Event toAdd) {
+        queue.add(toAdd);
+    }
+
+    public Optional<Event> poll() {
+        Event b = queue.poll();
+        return Optional.ofNullable(b);
+    }
+}

--- a/src/main/java/adris/altoclef/player2api/eventqueue/Greeting.java
+++ b/src/main/java/adris/altoclef/player2api/eventqueue/Greeting.java
@@ -5,22 +5,19 @@ import java.util.List;
 import adris.altoclef.player2api.AICommandBridge;
 import adris.altoclef.player2api.LLM.LLMState;
 import adris.altoclef.player2api.actions.GameAction;
-import adris.altoclef.player2api.actions.SendUserMessage;
 
-public class UserMessage extends Event {
+public class Greeting extends Event {
 
     private String msg;
 
-    public UserMessage(String msg) {
-        this.msg = msg;
+    public Greeting() {
     }
 
     @Override
     public List<GameAction> immediateHandle() {
-        System.out.println("[Events/UserMessage]: Adding user message event");
-        return List.of(new SendUserMessage(msg));
+        System.out.println("[Events/Greeting]: Adding Greeting event");
+        return List.of();
     }
-
 
     @Override
     public LLMState updateState(LLMState pvs) {

--- a/src/main/java/adris/altoclef/player2api/eventqueue/QueueProcessor.java
+++ b/src/main/java/adris/altoclef/player2api/eventqueue/QueueProcessor.java
@@ -1,0 +1,76 @@
+package adris.altoclef.player2api.eventqueue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import adris.altoclef.AltoClef;
+import adris.altoclef.player2api.AICommandBridge;
+import adris.altoclef.player2api.ConversationHistory;
+import adris.altoclef.player2api.LLM.LLMService;
+import adris.altoclef.player2api.LLM.LLMState;
+import adris.altoclef.player2api.actions.GameAction;
+import adris.altoclef.player2api.status.AgentStatus;
+import adris.altoclef.player2api.status.WorldStatus;
+
+public class QueueProcessor {
+    private static final ExecutorService QUEUE_PROCESSOR = Executors.newSingleThreadExecutor();
+
+    static boolean isCallingLLM = false;
+
+    static LLMState state = new LLMState();
+    static EventQueue eventQ = new EventQueue();
+
+    private static final List<GameAction> pendingActions = new ArrayList<>();
+
+    public static void addEvent(Event e){
+        eventQ.addEvent(e);
+    }
+
+    public static void onTick(AltoClef mod, AICommandBridge bridge) {
+        // handle any pending actions, wait if another thread is adding to it (should be
+        // done quickly)
+        synchronized (pendingActions) {
+            if (!pendingActions.isEmpty()) {
+                for (GameAction action : pendingActions) {
+                    action.handle(bridge, state);
+                }
+                pendingActions.clear();
+                return;
+            }
+        }
+
+        if (isCallingLLM)
+            return;
+
+        Optional<Event> topEventOption = eventQ.poll();
+
+        // if there is an event handle it (add to conversation history), otherwise get the LLM response and add the
+        // actions.
+        topEventOption.ifPresentOrElse(
+                evt -> evt.handle(state),
+                () -> {
+                    if (state.isLastMessageFromAssistant()) {
+                        // if last message was from assistant then dont do anything.
+                        return;
+                    }
+                    isCallingLLM = true;
+
+                    AgentStatus agentStatus = AgentStatus.fromMod(mod);
+                    WorldStatus worldStatus = WorldStatus.fromMod(mod);
+
+                    // WITHOUT BLOCKING, use the api to get the response
+                    QUEUE_PROCESSOR.execute(() -> {
+                        List<GameAction> actions = LLMService.GetResponse(state, agentStatus, worldStatus);
+
+                        synchronized (pendingActions) {
+                            pendingActions.addAll(actions);
+                        }
+
+                        isCallingLLM = false;
+                    });
+                });
+    }
+}

--- a/src/main/java/adris/altoclef/player2api/eventqueue/QueueProcessor.java
+++ b/src/main/java/adris/altoclef/player2api/eventqueue/QueueProcessor.java
@@ -35,7 +35,7 @@ public class QueueProcessor {
         long now = System.nanoTime();
 
         // minimum 5 seconds between LLM calls
-        boolean shouldProgress = (now - lastLLMCallTime > 5_000_000_000L);
+        boolean shouldProgress = (now - lastLLMCallTime > 10_000_000_000L);
 
         // handle any pending actions, wait if another thread is adding to it (should be
         // done quickly)
@@ -49,7 +49,7 @@ public class QueueProcessor {
             }
         }
 
-        if (isCallingLLM || shouldProgress)
+        if (isCallingLLM || !shouldProgress)
             return;
 
         Optional<Event> topEventOption = eventQ.poll();

--- a/src/main/java/adris/altoclef/player2api/eventqueue/QueueProcessor.java
+++ b/src/main/java/adris/altoclef/player2api/eventqueue/QueueProcessor.java
@@ -8,7 +8,6 @@ import java.util.concurrent.Executors;
 
 import adris.altoclef.AltoClef;
 import adris.altoclef.player2api.AICommandBridge;
-import adris.altoclef.player2api.ConversationHistory;
 import adris.altoclef.player2api.LLM.LLMService;
 import adris.altoclef.player2api.LLM.LLMState;
 import adris.altoclef.player2api.actions.GameAction;

--- a/src/main/java/adris/altoclef/player2api/eventqueue/UserMessage.java
+++ b/src/main/java/adris/altoclef/player2api/eventqueue/UserMessage.java
@@ -1,0 +1,18 @@
+package adris.altoclef.player2api.eventqueue;
+
+import adris.altoclef.player2api.LLM.LLMState;
+
+public class UserMessage extends Event {
+
+    private String msg;
+
+    public UserMessage(String msg) {
+        this.msg = msg;
+    }
+
+    @Override
+    public LLMState handle(LLMState pvs) {
+        pvs.addUserMessage(msg);
+        return pvs;
+    }
+}


### PR DESCRIPTION
At the moment we have a simple event queue that only consists of userMessage events, which just get added to conversation history as they are handled. When the event queue is empty, we send an LLM call on a separate thread, (also block any handling on the main thread) and when the conversation history is processed, it results in actions that are executed next tick on the main thread (do not need to wait for handling block)

it seems to work ok just have to fix a few bugs relating to login/greeting, and user message isnt printed in chat