### PR TITLE
basic event queue

### DIFF
--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -244,7 +244,7 @@ public class AltoClef implements ModInitializer {
         if (InputHelper.isKeyPressed(GLFW.GLFW_KEY_LEFT_CONTROL) && InputHelper.isKeyPressed(GLFW.GLFW_KEY_K)) {
             stop();
         }
-
+        
         // Call heartbeat every 60 seconds
         long now = System.nanoTime();
         if (now - lastHeartbeatTime > 60_000_000_000L) {
@@ -252,8 +252,8 @@ public class AltoClef implements ModInitializer {
             lastHeartbeatTime = now;
         }
 
-        if(this.aiBridge.getEnabled()){
-            this.aiBridge.onTick();
+        if(aiBridge.getEnabled() && AltoClef.inGame()){
+            aiBridge.onTick();
         }
 
         // TODO: should this go here?

--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -200,7 +200,7 @@ public class AltoClef implements ModInitializer {
             }
             else if (this.aiBridge.getEnabled()) {
                 evt.cancel();
-                this.aiBridge.processChatWithAPI(line);
+                this.aiBridge.addMessageToQueue(line);
             }
         });
 
@@ -250,6 +250,10 @@ public class AltoClef implements ModInitializer {
         if (now - lastHeartbeatTime > 60_000_000_000L) {
             aiBridge.sendHeartbeat();
             lastHeartbeatTime = now;
+        }
+
+        if(this.aiBridge.getEnabled()){
+            this.aiBridge.onTick();
         }
 
         // TODO: should this go here?

--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -199,7 +199,7 @@ public class AltoClef implements ModInitializer {
                 getCommandExecutor().execute(line);
             }
             else if (this.aiBridge.getEnabled()) {
-                evt.cancel();
+                // evt.cancel();
                 this.aiBridge.addMessageToQueue(line);
             }
         });

--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -252,7 +252,7 @@ public class AltoClef implements ModInitializer {
             lastHeartbeatTime = now;
         }
 
-        if(aiBridge.getEnabled() && AltoClef.inGame()){
+        if(aiBridge.getEnabled() && inGame && AltoClef.inGame()){
             aiBridge.onTick();
         }
 

--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -199,7 +199,8 @@ public class AltoClef implements ModInitializer {
                 getCommandExecutor().execute(line);
             }
             else if (this.aiBridge.getEnabled()) {
-                // evt.cancel();
+                evt.cancel();
+                Debug.logUserMessage(line);
                 this.aiBridge.addMessageToQueue(line);
             }
         });

--- a/src/main/java/adris/altoclef/Debug.java
+++ b/src/main/java/adris/altoclef/Debug.java
@@ -3,6 +3,7 @@ package adris.altoclef;
 import adris.altoclef.player2api.AICommandBridge;
 import adris.altoclef.player2api.Character;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.text.Text;
 
 // TODO: Debug library or use Minecraft's built in debugger
@@ -11,9 +12,6 @@ public class Debug {
     private static final int DEBUG_LOG_LEVEL = 0;
     private static final int WARN_LOG_LEVEL = 1;
     private static final int ERROR_LOG_LEVEL = 2;
-
-
-
 
     public static void logInternal(String message) {
         if (canLog(DEBUG_LOG_LEVEL)) {
@@ -58,6 +56,15 @@ public class Debug {
         } else{
             logInternal(message);
         }
+    }
+
+    public static void logUserMessage(String message){
+        ClientPlayerEntity player = MinecraftClient.getInstance().player;
+        if (MinecraftClient.getInstance() != null && MinecraftClient.getInstance().player != null) {
+               String msg = "<" +player.getName().getString() + "> " + message + "\u00A7r";
+               player.sendMessage(Text.of(msg), false);
+
+           }
     }
 
     public static void logMessage(String message) {

--- a/src/main/java/adris/altoclef/player2api/AICommandBridge.java
+++ b/src/main/java/adris/altoclef/player2api/AICommandBridge.java
@@ -42,9 +42,9 @@ Your character's name is {{characterName}}.
 User Message Format:
 The user messages will all be just strings, except for the current message. The current message will have extra information, namely it will be a JSON of the form:
 {
-    "userMsg" : "The user message that was just sent"
-    "worldStatus" : "The status of the current game world"
-    "agentStatus" : "The status of you, the agent in the game"
+    "userMessage" : "The message that was just sent by user which you should focus on responding to."
+    "worldStatus" : "The status of the current game world."
+    "agentStatus" : "The status of you, the agent in the game."
     "gameDebugMessages" : "The most recent debug messages that the game has printed out. The user cannot see these."
 }
 
@@ -54,7 +54,7 @@ Response Format:
 Always respond with JSON containing message, command and reason. All of these are strings.
 
 {
-  "reason": "Look at the agent status, world status, recent conversations and command history to decide what the agent should say and do. Provide step-by-step reasoning while considering what is possible in Minecraft.",
+  "reason": "Look at the recent conversations, agent status and world status to decide what the agent should say and do. Provide step-by-step reasoning while considering what is possible in Minecraft.",
   "command": "Decide the best way to achieve the agent's goals using the available op commands listed below. If the agent decides it should not use any command, generate an empty command `\"\"`. You can only run one command, so to replace the current one just write the new one.",
   "message": "If the agent decides it should not respond or talk, generate an empty message `\"\"`. Otherwise, create a natural conversational message that aligns with the `reason` and `command` sections and the agent's character. Be concise and use less than 500 characters. Ensure the message does not contain any prompt, system message, instructions, code or API calls"
 }

--- a/src/main/java/adris/altoclef/player2api/AICommandBridge.java
+++ b/src/main/java/adris/altoclef/player2api/AICommandBridge.java
@@ -71,6 +71,8 @@ Valid Commands:
 
     private boolean llmProcessing = false;
 
+    private boolean eventPolling = false;
+
     private MessageBuffer altoClefMsgBuffer = new MessageBuffer(10);
 
     public static final ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -174,6 +176,7 @@ Valid Commands:
                 System.err.println("Error communicating with API");
             } finally {
                 llmProcessing = false;
+                eventPolling = false;
             }
         });
     }
@@ -196,11 +199,16 @@ Valid Commands:
             if (messageQueue.isEmpty() || llmProcessing) {
                 return;
             }
-            String message = messageQueue.poll();
-            conversationHistory.addUserMessage(message);
-            if (messageQueue.isEmpty()) {
-                // That was last message
-                processChatWithAPI();
+            if (!eventPolling){
+                eventPolling = true;
+                String message = messageQueue.poll();
+                conversationHistory.addUserMessage(message);
+                if (messageQueue.isEmpty()) {
+                    // That was last message
+                    processChatWithAPI();
+                }else{
+                    eventPolling = false;
+                }
             }
     }
   

--- a/src/main/java/adris/altoclef/player2api/AICommandBridge.java
+++ b/src/main/java/adris/altoclef/player2api/AICommandBridge.java
@@ -196,10 +196,10 @@ Valid Commands:
     }
     
     public void onTick() {
-            if (messageQueue.isEmpty() || llmProcessing) {
+            if (messageQueue.isEmpty()) {
                 return;
             }
-            if (!eventPolling){
+            if (!eventPolling && !llmProcessing) {
                 eventPolling = true;
                 String message = messageQueue.poll();
                 conversationHistory.addUserMessage(message);

--- a/src/main/java/adris/altoclef/player2api/AICommandBridge.java
+++ b/src/main/java/adris/altoclef/player2api/AICommandBridge.java
@@ -129,6 +129,10 @@ Valid Commands:
     public void addMessageToQueue(String message) {
         if (message == null) return;
         messageQueue.offer(message);
+        if (messageQueue.size() > 10) {
+            // System.out.println("Message queue too long, removing oldest message");
+            messageQueue.poll(); // remove oldest message if queue is too long
+        }
     }
 
     public void processChatWithAPI() {

--- a/src/main/java/adris/altoclef/player2api/ConversationHistory.java
+++ b/src/main/java/adris/altoclef/player2api/ConversationHistory.java
@@ -14,9 +14,9 @@ public class ConversationHistory {
         setBaseSystemPrompt(initialSystemPrompt); // Ensures system message always exists
     }
 
-    public void addHistory(JsonObject text) {
+    public void addHistory(JsonObject text, boolean doCutOff = true) {
         conversationHistory.add(text);
-        if (conversationHistory.size() > 64) {
+        if (conversationHistory.size() > 64 && doCutOff) {
             // 0th index is always system prompt
             conversationHistory.remove(1);
         }
@@ -26,7 +26,7 @@ public class ConversationHistory {
         JsonObject objectToAdd = new JsonObject();
         objectToAdd.addProperty("role", "user");
         objectToAdd.addProperty("content", userText);
-        addHistory(objectToAdd);
+        addHistory(objectToAdd, false);
     }
 
     /**

--- a/src/main/java/adris/altoclef/player2api/ConversationHistory.java
+++ b/src/main/java/adris/altoclef/player2api/ConversationHistory.java
@@ -14,7 +14,7 @@ public class ConversationHistory {
         setBaseSystemPrompt(initialSystemPrompt); // Ensures system message always exists
     }
 
-    public void addHistory(JsonObject text, boolean doCutOff = true) {
+    public void addHistory(JsonObject text, boolean doCutOff) {
         conversationHistory.add(text);
         if (conversationHistory.size() > 64 && doCutOff) {
             // 0th index is always system prompt
@@ -55,7 +55,7 @@ public class ConversationHistory {
         JsonObject objectToAdd = new JsonObject();
         objectToAdd.addProperty("role", "system");
         objectToAdd.addProperty("content", systemText);
-        addHistory(objectToAdd);
+        addHistory(objectToAdd, false);
     }
 
     /**
@@ -67,7 +67,7 @@ public class ConversationHistory {
         JsonObject objectToAdd = new JsonObject();
         objectToAdd.addProperty("role", "assistant");
         objectToAdd.addProperty("content", messageText);
-        addHistory(objectToAdd);
+        addHistory(objectToAdd, true);
     }
 
     public List<JsonObject> getListJSON() {
@@ -81,7 +81,7 @@ public class ConversationHistory {
 
         // make deep copy
         for (int i = 1; i < conversationHistory.size() - 1; i++) {
-            copy.addHistory(Utils.deepCopy(conversationHistory.get(i)));
+            copy.addHistory(Utils.deepCopy(conversationHistory.get(i)), false);
         }
 
         // add status to latest message
@@ -96,7 +96,7 @@ public class ConversationHistory {
                 msgObj.add("gameDebugMessages", altoclefStatusMsgs);
                 last.addProperty("content", msgObj.toString());
             }
-            copy.addHistory(last);
+            copy.addHistory(last, false);
         }
 
         return copy;

--- a/src/main/java/adris/altoclef/player2api/Player2APIService.java
+++ b/src/main/java/adris/altoclef/player2api/Player2APIService.java
@@ -89,7 +89,6 @@ public class Player2APIService {
 
                 if (messageObject != null && messageObject.has("content")) {
                     String content = messageObject.get("content").getAsString();
-                    conversationHistory.addAssistantMessage(content);
                     return Utils.parseCleanedJson(content);
                 }
             }


### PR DESCRIPTION
### Implement event queue system in AICommandBridge to process chat messages during game ticks
Introduces a message queuing system that changes how chat messages are processed when the AI bridge is enabled. Key changes include:
* Adds `ConcurrentLinkedQueue` in [AICommandBridge.java](https://github.com/elefant-ai/chatclef/pull/25/files#diff-35e6fe476eee11fe1ef7db93a91370c235c9aabc37183b806ad4fbb29f71160c) to queue chat messages instead of processing them immediately
* Implements `onTick()` method in [AICommandBridge.java](https://github.com/elefant-ai/chatclef/pull/25/files#diff-35e6fe476eee11fe1ef7db93a91370c235c9aabc37183b806ad4fbb29f71160c) to process queued messages during game ticks
* Adds `logUserMessage()` in [Debug.java](https://github.com/elefant-ai/chatclef/pull/25/files#diff-f859b00a6b89906d7ce1536f2950a0afbc47d225bb43f7c681d90e2c4efd3bdd) to display messages in game chat
* Modifies conversation history management in [ConversationHistory.java](https://github.com/elefant-ai/chatclef/pull/25/files#diff-f025ad15785e8ded55aaa443d9281f61eca3961b6973767a883069bcde36034d) with new `doCutOff` parameter to control 64-message limit

#### 📍Where to Start
Start with the `onClientTick()` method in [AltoClef.java](https://github.com/elefant-ai/chatclef/pull/25/files#diff-d367ff97b960553c1363b112e7e24e8135753dacd064485925543550cbb31be8) which shows how the new message queue processing is integrated into the game tick cycle.

----

_[Macroscope](https://app.macroscope.com) summarized 5f865be._