### PR TITLE
Fix give item

### DIFF
--- a/src/main/java/adris/altoclef/control/SlotHandler.java
+++ b/src/main/java/adris/altoclef/control/SlotHandler.java
@@ -51,7 +51,9 @@ public class SlotHandler {
 
 
     public void clickSlot(Slot slot, int mouseButton, SlotActionType type) {
-        if (!canDoSlotAction()) return;
+        if (!canDoSlotAction()) {
+            return;
+        }
 
         if (slot.getWindowSlot() == -1) {
             clickSlot(PlayerSlot.UNDEFINED, 0, SlotActionType.PICKUP);


### PR DESCRIPTION
### Add 0.4-second timeout between item throws in `GiveItemToPlayerTask` to fix item giving functionality
* Implements rate limiting in [GiveItemToPlayerTask.java](https://github.com/elefant-ai/chatclef/pull/27/files#diff-cf622c4401bd5b64432f5d3097c31f8d0dc50a2a94620f483cdde0ae1b8ecc5e) by adding a `TimerGame` with 0.4-second timeout between item throws
* Replaces direct slot clicking with dedicated `ThrowCursorTask` for handling cursor items
* Adds debug output for slot tracking
* Adds curly braces to return statement in [SlotHandler.java](https://github.com/elefant-ai/chatclef/pull/27/files#diff-84d7c8fb13e66e207721dee30162773fc3db6794583a19d89a1949229b18cc50) `clickSlot` method

#### 📍Where to Start
Start with the modified item throwing logic in [GiveItemToPlayerTask.java](https://github.com/elefant-ai/chatclef/pull/27/files#diff-cf622c4401bd5b64432f5d3097c31f8d0dc50a2a94620f483cdde0ae1b8ecc5e) which contains the core functional changes.

----

_[Macroscope](https://app.macroscope.com) summarized 2953c8f._