### PR TITLE
Give command: out of range case issues fix AND other tweaks to give

### DIFF
--- a/src/main/java/adris/altoclef/commands/GiveCommand.java
+++ b/src/main/java/adris/altoclef/commands/GiveCommand.java
@@ -48,11 +48,20 @@ public class GiveCommand extends Command {
                 }
             }
         }
+
+        // Fail if user not found in render distance or not in user list
+        if (!mod.getEntityTracker().isPlayerLoaded(username)) {
+            String nearbyUsernames = String.join(",", mod.getEntityTracker().getAllLoadedPlayerUsernames());
+            Debug.logMessage("No user in render distance found with username \"" + username + "\". Maybe this was a typo or there is a user with a similar name around? Nearby users: [" + nearbyUsernames + "].");
+            finish();
+            return;
+        }
+
         if (target != null) {
             Debug.logMessage("USER: " + username + " : ITEM: " + item + " x " + count);
             mod.runUserTask(new GiveItemToPlayerTask(username, target), this::finish);
         } else {
-            mod.log("Item not found or task does not exist for item: " + item);
+            Debug.logMessage("Item not found or task does not exist for item: " + item);
             finish();
         }
     }

--- a/src/main/java/adris/altoclef/tasks/entity/GiveItemToPlayerTask.java
+++ b/src/main/java/adris/altoclef/tasks/entity/GiveItemToPlayerTask.java
@@ -1,6 +1,7 @@
 package adris.altoclef.tasks.entity;
 
 import adris.altoclef.AltoClef;
+import adris.altoclef.BotBehaviour;
 import adris.altoclef.Debug;
 import adris.altoclef.TaskCatalogue;
 import adris.altoclef.tasks.movement.FollowPlayerTask;
@@ -47,6 +48,11 @@ public class GiveItemToPlayerTask extends Task {
     protected void onStart() {
         droppingItems = false;
         throwTarget.clear();
+
+        BotBehaviour botBehaviour = AltoClef.getInstance().getBehaviour();
+
+        botBehaviour.push();
+        botBehaviour.addProtectedItems(ItemTarget.getMatches(targets));
     }
 
     @Override
@@ -117,25 +123,34 @@ public class GiveItemToPlayerTask extends Task {
             return resourceTask;
         }
 
-        if (targetPos.isInRange(mod.getPlayer().getPos(), 1.5)) {
+        if (targetPos.isInRange(mod.getPlayer().getPos(), 4)) {
             if (!mod.getEntityTracker().isPlayerLoaded(playerName)) {
                 String nearbyUsernames = String.join(",", mod.getEntityTracker().getAllLoadedPlayerUsernames());
                 fail("Failed to get to player \"" + this.playerName + "\". We moved to where we last saw them but now have no idea where they are. Nearby players: [" + nearbyUsernames + "]");
                 return null;
             }
-            droppingItems = true;
-            throwTarget.addAll(Arrays.asList(targets));
 
-            _throwTimeout.reset();
+            var p = mod.getEntityTracker().getPlayerEntity(playerName).get();
+
+            // We must be At or ABOVE the player (or super close)
+            if (p.getBlockPos().getY() <= mod.getPlayer().getBlockPos().getY() || p.getPos().distanceTo(mod.getPlayer().getPos()) <= 0.5) {
+                // We must be able to SEE the player we're dropping to
+                if (LookHelper.seesPlayer(p, mod.getPlayer(), 6)) {
+                    droppingItems = true;
+                    throwTarget.addAll(Arrays.asList(targets));
+        
+                    _throwTimeout.reset();    
+                }
+            }
         }
 
         setDebugState("Going to player...");
-        return new FollowPlayerTask(playerName);
+        return new FollowPlayerTask(playerName, 0.5);
     }
 
     @Override
     protected void onStop(Task interruptTask) {
-
+        AltoClef.getInstance().getBehaviour().pop();
     }
 
     @Override

--- a/src/main/java/adris/altoclef/tasks/entity/GiveItemToPlayerTask.java
+++ b/src/main/java/adris/altoclef/tasks/entity/GiveItemToPlayerTask.java
@@ -61,7 +61,8 @@ public class GiveItemToPlayerTask extends Task {
         Optional<Vec3d> lastPos = mod.getEntityTracker().getPlayerMostRecentPosition(playerName);
 
         if (lastPos.isEmpty()) {
-            setDebugState("No player found/detected. Doing nothing until player loads into render distance.");
+            String nearbyUsernames = String.join(",", mod.getEntityTracker().getAllLoadedPlayerUsernames());
+            fail("No user in render distance found with username \"" + this.playerName + "\". Maybe this was a typo or there is a user with a similar name around? Nearby users: [" + nearbyUsernames + "].");
             return null;
         }
         Vec3d targetPos = lastPos.get().add(0, 0.2f, 0);
@@ -118,8 +119,8 @@ public class GiveItemToPlayerTask extends Task {
 
         if (targetPos.isInRange(mod.getPlayer().getPos(), 1.5)) {
             if (!mod.getEntityTracker().isPlayerLoaded(playerName)) {
-                mod.logWarning("Failed to get to player \"" + playerName + "\". We moved to where we last saw them but now have no idea where they are.");
-                stop();
+                String nearbyUsernames = String.join(",", mod.getEntityTracker().getAllLoadedPlayerUsernames());
+                fail("Failed to get to player \"" + this.playerName + "\". We moved to where we last saw them but now have no idea where they are. Nearby players: [" + nearbyUsernames + "]");
                 return null;
             }
             droppingItems = true;

--- a/src/main/java/adris/altoclef/tasks/movement/FollowPlayerTask.java
+++ b/src/main/java/adris/altoclef/tasks/movement/FollowPlayerTask.java
@@ -12,8 +12,15 @@ public class FollowPlayerTask extends Task {
 
     private final String _playerName;
 
-    public FollowPlayerTask(String playerName) {
+    private final double _followDistance;
+
+    public FollowPlayerTask(String playerName, double followDistance) {
         _playerName = playerName;
+        _followDistance = followDistance;
+    }
+
+    public FollowPlayerTask(String playerName) {
+        this(playerName, 2);
     }
 
     @Override
@@ -44,7 +51,7 @@ public class FollowPlayerTask extends Task {
             // Go to last location
             return new GetToBlockTask(new BlockPos((int) target.x, (int) target.y, (int) target.z), false);
         }
-        return new GetToEntityTask(player.get(), 2);
+        return new GetToEntityTask(player.get(), _followDistance);
     }
 
     @Override
@@ -55,7 +62,7 @@ public class FollowPlayerTask extends Task {
     @Override
     protected boolean isEqual(Task other) {
         if (other instanceof FollowPlayerTask task) {
-            return task._playerName.equals(_playerName);
+            return task._playerName.equals(_playerName) && Math.abs(_followDistance - task._followDistance) < 0.1;
         }
         return false;
     }

--- a/src/main/java/adris/altoclef/tasksystem/Task.java
+++ b/src/main/java/adris/altoclef/tasksystem/Task.java
@@ -90,6 +90,11 @@ public abstract class Task {
         stopped = true;
     }
 
+    public void fail(String reason) {
+        stop();
+        Debug.logMessage("Task FAILED: " + reason);
+    }
+
     /**
      * Lets the task know it's execution has been "suspended"
      * <p>

--- a/src/main/java/adris/altoclef/trackers/EntityTracker.java
+++ b/src/main/java/adris/altoclef/trackers/EntityTracker.java
@@ -284,6 +284,12 @@ public class EntityTracker extends Tracker {
         }
     }
 
+    public List<String> getAllLoadedPlayerUsernames() {
+        synchronized (BaritoneHelper.MINECRAFT_LOCK) {
+            return new ArrayList<>(playerMap.keySet());
+        }
+    }
+
     /**
      * Get where we last saw a player, if we saw them at all.
      *


### PR DESCRIPTION
### Fix out-of-range issues and improve player validation in GiveCommand by adding render distance checks and increasing interaction range to 4 blocks
* Adds player validation in `GiveCommand` to check if target is within render distance, with nearby player listing on failure
* Increases player interaction range from 1.5 to 4 blocks in [GiveItemToPlayerTask.java](https://github.com/elefant-ai/chatclef/pull/32/files#diff-cf622c4401bd5b64432f5d3097c31f8d0dc50a2a94620f483cdde0ae1b8ecc5e)
* Adds item protection and positioning requirements in [GiveItemToPlayerTask.java](https://github.com/elefant-ai/chatclef/pull/32/files#diff-cf622c4401bd5b64432f5d3097c31f8d0dc50a2a94620f483cdde0ae1b8ecc5e)
* Implements customizable follow distance in [FollowPlayerTask.java](https://github.com/elefant-ai/chatclef/pull/32/files#diff-08a523a1da5d8aaec7b495593886b2a21f04040ad06ef6748cc8e42404b55f15)
* Adds `fail()` method to [Task.java](https://github.com/elefant-ai/chatclef/pull/32/files#diff-a1d114222d9e47bdf20d69419482ca287c5624027b6d96f4ed00b975c1a7da4e) for standardized failure handling
* Adds `getAllLoadedPlayerUsernames()` to [EntityTracker.java](https://github.com/elefant-ai/chatclef/pull/32/files#diff-7a5e56d433c4a80c9fc66e1a74774b42b7abd07c1db83c65a36057fa0a1826f4)

#### 📍Where to Start
Start with the `GiveCommand` class in [GiveCommand.java](https://github.com/elefant-ai/chatclef/pull/32/files#diff-fcf9fac2fcc1ccfcad0e040e5b1212eb06b9071463b9863d7f0b481ba86854f0) which contains the main command logic and validation changes.

----

_[Macroscope](https://app.macroscope.com) summarized 5142f3e._