### PR TITLE
Fix locate structure crafting bug

### DIFF
--- a/src/main/java/adris/altoclef/tasks/movement/GoToStrongholdPortalTask.java
+++ b/src/main/java/adris/altoclef/tasks/movement/GoToStrongholdPortalTask.java
@@ -37,8 +37,9 @@ public class GoToStrongholdPortalTask extends Task {
             If there search it
          */
         if (_strongholdCoordinates == null) {
+            // DO NOT do this (this is a terrible idea! breaks crafting!)
             // in case any screen is open, prevents from getting stuck
-            StorageHelper.closeScreen();
+            // StorageHelper.closeScreen();
 
             _strongholdCoordinates = _locateCoordsTask.getStrongholdCoordinates().orElse(null);
             if (_strongholdCoordinates == null) {


### PR DESCRIPTION
### Remove automatic screen closing in `GoToStrongholdPortalTask` to fix structure crafting bug
Removes the automatic screen closing behavior in [GoToStrongholdPortalTask.java](https://github.com/elefant-ai/chatclef/pull/42/files#diff-904833ac200a8da4deddba63ea9ad83e9b475a85b34c1b5d9232e4d5ea05e85c) when stronghold coordinates are unknown, preventing interference with active crafting operations.

#### 📍Where to Start
Start with the commented out `StorageHelper.closeScreen()` call in [GoToStrongholdPortalTask.java](https://github.com/elefant-ai/chatclef/pull/42/files#diff-904833ac200a8da4deddba63ea9ad83e9b475a85b34c1b5d9232e4d5ea05e85c).

----

_[Macroscope](https://app.macroscope.com) summarized 436f4df._