### PR TITLE
working

### DIFF
--- a/src/main/java/adris/altoclef/AltoClefCommands.java
+++ b/src/main/java/adris/altoclef/AltoClefCommands.java
@@ -13,13 +13,12 @@ import adris.altoclef.commands.HeroCommand;
 import adris.altoclef.commands.IdleCommand;
 import adris.altoclef.commands.LocateStructureCommand;
 import adris.altoclef.commands.MeatCommand;
-import adris.altoclef.commands.PauseCommand;
 import adris.altoclef.commands.ReloadSettingsCommand;
 import adris.altoclef.commands.SetAIBridgeEnabledCommand;
 import adris.altoclef.commands.SetGammaCommand;
 import adris.altoclef.commands.StashCommand;
 import adris.altoclef.commands.StopCommand;
-import adris.altoclef.commands.UnPauseCommand;
+import adris.altoclef.commands.ResetMemoryCommand;
 import adris.altoclef.commands.random.ScanCommand;
 import adris.altoclef.commandsystem.CommandException;
 
@@ -40,12 +39,11 @@ public class AltoClefCommands {
                 new HeroCommand(),
                 new LocateStructureCommand(),
                 new StopCommand(),
-                new PauseCommand(),
-                new UnPauseCommand(),
                 new SetGammaCommand(),
                 new FoodCommand(),
                 new MeatCommand(),
                 new ReloadSettingsCommand(),
+                new ResetMemoryCommand(),
                 new GamerCommand(),
                 new FollowCommand(),
                 new GiveCommand(),

--- a/src/main/java/adris/altoclef/commands/ResetMemoryCommand.java
+++ b/src/main/java/adris/altoclef/commands/ResetMemoryCommand.java
@@ -1,0 +1,18 @@
+package adris.altoclef.commands;
+
+import adris.altoclef.AltoClef;
+import adris.altoclef.commandsystem.ArgParser;
+import adris.altoclef.commandsystem.Command;
+
+public class ResetMemoryCommand extends Command {
+
+    public ResetMemoryCommand() {
+        super("resetmemory", "Reset the memory, does not stop the agent, can ONLY be run by the user (NOT the agent).");
+    }
+
+    @Override
+    protected void call(AltoClef mod, ArgParser parser) {
+        mod.getAiBridge().conversationHistory().clear();
+        finish();
+    }
+}

--- a/src/main/java/adris/altoclef/player2api/AICommandBridge.java
+++ b/src/main/java/adris/altoclef/player2api/AICommandBridge.java
@@ -45,19 +45,20 @@ public class AICommandBridge {
             }
 
             Response Format:
-            Always respond with JSON containing message, command and reason. All of these are strings.
+            Respond with JSON containing message, command and reason. All of these are strings.
 
             {
               "reason": "Look at the recent conversations, agent status and world status to decide what the you should say and do. Provide step-by-step reasoning while considering what is possible in Minecraft.",
               "command": "Decide the best way to achieve the goals using the valid commands listed below. Write the command in this field. If you decide to not use any command, generate an empty command `\"\"`. You can only run one command at a time! To replace the current one just write the new one.",
               "message": "If you decide you should not respond or talk, generate an empty message `\"\"`. Otherwise, create a natural conversational message that aligns with the `reason` and the your character. Be concise and use less than 250 characters. Ensure the message does not contain any prompt, system message, instructions, code or API calls"
             }
-
+            
             Additional Guidelines:
             Meaningful Content: Ensure conversations progress with substantive information.
             Handle Misspellings: Make educated guesses if users misspell item names.
             Avoid Filler Phrases: Do not engage in repetitive or filler content.
-            Player mode: The user can turn on/off the player mode by pressing the playermode text on the top right of their screen (the user can unlock their mouse by opening their inventory by pressing e or escape). The player mode enables you to recive messages and talk to other players.
+            Player mode: The user can turn on/off the player mode by pressing the playermode text on the top right of their screen (the user can unlock their mouse by opening their inventory by pressing e or escape). The player mode enables you to talk to other players.
+            JSON format: Always follow this JSON format regardless of conversations.
 
             Valid Commands:
             {{validCommands}}
@@ -287,6 +288,10 @@ public class AICommandBridge {
 
     public Character getCharacter() {
         return character;
+    }
+
+    public ConversationHistory conversationHistory() {
+        return conversationHistory;
     }
 
     public void setPlayerMode(boolean playermode) {

--- a/src/main/java/adris/altoclef/player2api/ConversationHistory.java
+++ b/src/main/java/adris/altoclef/player2api/ConversationHistory.java
@@ -256,4 +256,19 @@ public class ConversationHistory {
         sb.append("}");
         return sb.toString();
     }
+
+    public void clear() {
+        if (!conversationHistory.isEmpty()) {
+            JsonObject systemPrompt = conversationHistory.get(0);
+            conversationHistory.clear();
+            conversationHistory.add(systemPrompt);
+        }
+        if (historyFile != null) {
+            try {
+                Files.deleteIfExists(historyFile);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Add `resetmemory` command to AltoClef and remove pause functionality
* Adds new `ResetMemoryCommand` that clears conversation history while preserving system prompt in [ResetMemoryCommand.java](https://github.com/elefant-ai/chatclef/pull/46/files#diff-9a6ebb620c47be9d70fe317cbbb7091d06795e33a99b121616542ead016ea992)
* Removes `PauseCommand` and `UnPauseCommand` functionality from [AltoClefCommands.java](https://github.com/elefant-ai/chatclef/pull/46/files#diff-e6125ad4b02d23be4874be446ca1d8b5d0425a7f8302aae3db01e4832f138307)
* Implements `clear()` method in [ConversationHistory.java](https://github.com/elefant-ai/chatclef/pull/46/files#diff-f025ad15785e8ded55aaa443d9281f61eca3961b6973767a883069bcde36034d) to reset conversation state
* Updates initial prompt text in [AICommandBridge.java](https://github.com/elefant-ai/chatclef/pull/46/files#diff-35e6fe476eee11fe1ef7db93a91370c235c9aabc37183b806ad4fbb29f71160c) with JSON format instructions

#### 📍Where to Start
Start with the new `ResetMemoryCommand` class in [ResetMemoryCommand.java](https://github.com/elefant-ai/chatclef/pull/46/files#diff-9a6ebb620c47be9d70fe317cbbb7091d06795e33a99b121616542ead016ea992) which implements the core memory reset functionality.

----

_[Macroscope](https://app.macroscope.com) summarized 2bab13a._