### PR TITLE
Improve deposit command to work w/ llm and avoid searching super far

### DIFF
--- a/src/main/java/adris/altoclef/AltoClefCommands.java
+++ b/src/main/java/adris/altoclef/AltoClefCommands.java
@@ -34,7 +34,8 @@ public class AltoClefCommands {
                 new GetCommand(),
                 new EquipCommand(),
                 new DepositCommand(),
-                new StashCommand(),
+                // disabled: not useful to LLM agent
+                // new StashCommand(),
                 new GotoCommand(),
                 new IdleCommand(),
                 new HeroCommand(),

--- a/src/main/java/adris/altoclef/commands/DepositCommand.java
+++ b/src/main/java/adris/altoclef/commands/DepositCommand.java
@@ -3,17 +3,35 @@ package adris.altoclef.commands;
 import adris.altoclef.AltoClef;
 import adris.altoclef.commandsystem.*;
 import adris.altoclef.tasks.container.StoreInAnyContainerTask;
+import adris.altoclef.tasks.container.StoreInContainerTask;
 import adris.altoclef.util.ItemTarget;
+import adris.altoclef.util.helpers.ItemHelper;
 import adris.altoclef.util.helpers.StorageHelper;
 import adris.altoclef.util.slots.PlayerSlot;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolItem;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.ArrayUtils;
 
 public class DepositCommand extends Command {
+
+    // TODO: Configuration
+    private static final int NEARBY_RANGE = 20;
+
+    private static final Block[] VALID_CONTAINERS = Stream.concat(Arrays.stream(new Block[]{Blocks.CHEST, Blocks.TRAPPED_CHEST, Blocks.BARREL}), Arrays.stream(ItemHelper.itemsToBlocks(ItemHelper.SHULKER_BOXES))).toArray(Block[]::new);
+
     public DepositCommand() throws CommandException {
-        super("deposit", "Deposit ALL of our items", new Arg(ItemList.class, "items (empty for ALL non gear items)", null, 0, false));
+        super("deposit", "Deposit our items to a nearby chest, making a chest if one doesn't exist. Pass no arguments to depisot ALL items. Examples: `deposit` deposits ALL items, `deposit diamond 2` deposits 2 diamonds.", new Arg(ItemList.class, "items (empty for ALL non gear items)", null, 0, false));
     }
 
     public static ItemTarget[] getAllNonEquippedOrToolItemsAsTarget(AltoClef mod) {
@@ -35,11 +53,61 @@ public class DepositCommand extends Command {
     protected void call(AltoClef mod, ArgParser parser) throws CommandException {
         ItemList itemList = parser.get(ItemList.class);
         ItemTarget[] items;
+
+        if (itemList != null) {
+            // Validation that we have the items:
+            Map<String, Integer> countsLeftover = new HashMap<>();
+
+            // populate starting requirements
+            for (ItemTarget itemTarget : itemList.items) {
+                String name = itemTarget.getCatalogueName();
+                countsLeftover.put(name, countsLeftover.getOrDefault(name, 0) + itemTarget.getTargetCount());
+            }
+
+            // subtract counts
+            for (int i = 0; i < mod.getPlayer().getInventory().size(); ++i) {
+                ItemStack stack = mod.getPlayer().getInventory().getStack(i);
+                if (!stack.isEmpty()) {
+                    String name = ItemHelper.stripItemName(stack.getItem());
+                    int count = stack.getCount();
+                    if (countsLeftover.containsKey(name)) {
+                        countsLeftover.put(name, countsLeftover.get(name) - count);
+                        if (countsLeftover.get(name) <= 0) {
+                            countsLeftover.remove(name);
+                        }
+                    }
+                }
+            }
+
+            // invalid!
+            if (countsLeftover.size() != 0) {
+                String leftover = String.join(",", countsLeftover.entrySet().stream().map(e -> e.getKey() + " x " + e.getValue().toString()).toList());
+                mod.log("Insuffucient items in inventory to deposit. We still need: " + leftover + ".");
+                finish();
+                return;
+            }
+        }
+
         if (itemList == null) {
             items = getAllNonEquippedOrToolItemsAsTarget(mod);
         } else {
             items = itemList.items;
         }
+
+        // BlockScanner blockScanner = mod.getBlockScanner();
+        // Optional<BlockPos> container = blockScanner.getNearestBlock(VALID_CONTAINERS);
+
+        // if (!container.isPresent() || !container.get().isWithinDistance(mod.getPlayer().getPos(), NEARBY_RANGE)) {
+        //     // Just use a random container
+        //     mod.runUserTask(new StoreInAnyContainerTask(false, items), this::finish);
+        //     return;
+        //     // mod.log("No container (chest, barrel, shulker) found nearby. Move close to a container and try again.");
+        //     // finish();
+        //     // return;
+        // }
+
+        // // Store in the nearby container
+        // mod.runUserTask(new StoreInContainerTask(container.get(), false, items), this::finish);
 
         mod.runUserTask(new StoreInAnyContainerTask(false, items), this::finish);
     }

--- a/src/main/java/adris/altoclef/tasks/container/StoreInContainerTask.java
+++ b/src/main/java/adris/altoclef/tasks/container/StoreInContainerTask.java
@@ -6,19 +6,25 @@ import adris.altoclef.tasks.slot.MoveItemToSlotFromInventoryTask;
 import adris.altoclef.tasksystem.Task;
 import adris.altoclef.trackers.storage.ContainerCache;
 import adris.altoclef.util.ItemTarget;
+import adris.altoclef.util.helpers.ItemHelper;
 import adris.altoclef.util.helpers.StorageHelper;
 import adris.altoclef.util.slots.Slot;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Moves items from your inventory to a storage container.
  */
 public class StoreInContainerTask extends AbstractDoToStorageContainerTask {
+
+    public static final Block[] CONTAINER_BLOCKS = Stream.concat(Arrays.stream(new Block[]{Blocks.CHEST, Blocks.TRAPPED_CHEST, Blocks.BARREL}), Arrays.stream(ItemHelper.itemsToBlocks(ItemHelper.SHULKER_BOXES))).toArray(Block[]::new);
 
     private final BlockPos targetContainer;
     private final boolean getIfNotPresent;


### PR DESCRIPTION
### Limit deposit command search range to 50 blocks and validate inventory items to improve LLM agent functionality
* Adds distance limitations to container search in `StoreInAnyContainerTask`, restricting searches to containers within 50 blocks (or 70 blocks if already targeting a container)
* Implements inventory validation in `DepositCommand` to verify items exist before attempting deposits
* Centralizes container block definitions by moving them from `StoreInAnyContainerTask` to `StoreInContainerTask`
* Disables `StashCommand` in [AltoClefCommands.java](https://github.com/elefant-ai/chatclef/pull/47/files#diff-ef01ec9320bfd127c465322f8b181f86dcc57368cb284e5b2958e59429430050)

#### 📍Where to Start
Start with the `DepositCommand` class in [DepositCommand.java](https://github.com/elefant-ai/chatclef/pull/47/files#diff-8605d0f09e3c58245b843fc0a282b13cfe5d76d5cce4083c4977cdb3909fbb46) which contains the core validation logic changes and interfaces with the storage tasks.

----

_[Macroscope](https://app.macroscope.com) summarized 3cd8ef4._