### PR TITLE
patch fix to prevent mob defense from doing nothing

### DIFF
--- a/src/main/java/adris/altoclef/chains/MobDefenseChain.java
+++ b/src/main/java/adris/altoclef/chains/MobDefenseChain.java
@@ -120,6 +120,10 @@ public class MobDefenseChain extends SingleTaskChain {
     @Override
     public float getPriority() {
         cachedLastPriority = getPriorityInner();
+        if (getCurrentTask() == null) {
+            // We're doing nothing! Don't run.
+            cachedLastPriority = 0;
+        }
         prevHealth = AltoClef.getInstance().getPlayer().getHealth();
         return cachedLastPriority;
     }


### PR DESCRIPTION
### Fix MobDefenseChain to prevent activation when no task is active
Adds a null check in the `getPriority()` method of [MobDefenseChain.java](https://github.com/elefant-ai/chatclef/pull/51/files#diff-a285176498fa29e93d32e0c4d0af2752c2c1dabc60f66e9aa660696744ad01f2) that sets `cachedLastPriority` to 0 when there is no current task, preventing the chain from executing during idle states.

#### 📍Where to Start
Start with the `getPriority()` method in [MobDefenseChain.java](https://github.com/elefant-ai/chatclef/pull/51/files#diff-a285176498fa29e93d32e0c4d0af2752c2c1dabc60f66e9aa660696744ad01f2) where the null check condition has been added.

----

_[Macroscope](https://app.macroscope.com) summarized 48cd53b._