### PR TITLE
Adris/avoid mining user blocks

### DIFF
--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -161,13 +161,10 @@ public class AltoClef implements ModInitializer {
         // This code should be run after Minecraft loads everything else in.
         // This is the actual start point, controlled by a mixin.
 
-        initializeBaritoneSettings();
-
         // Central Managers
         commandExecutor = new CommandExecutor(this);
         taskRunner = new TaskRunner(this);
         trackerManager = new TrackerManager(this);
-        botBehaviour = new BotBehaviour(this);
         extraController = new PlayerExtraController(this);
 
         // Task chains
@@ -202,6 +199,12 @@ public class AltoClef implements ModInitializer {
 
         butler = new Butler(this);
         aiBridge = new AICommandBridge(commandExecutor, this);
+
+        // Baritone
+        initializeBaritoneSettings();
+
+        // Initialize behavior (after baritone and other state that is set to start)
+        botBehaviour = new BotBehaviour(this);
 
         initializeCommands();
 

--- a/src/main/java/adris/altoclef/AltoClef.java
+++ b/src/main/java/adris/altoclef/AltoClef.java
@@ -76,6 +76,7 @@ public class AltoClef implements ModInitializer {
     private SimpleChunkTracker chunkTracker;
     private MiscBlockTracker miscBlockTracker;
     private CraftingRecipeTracker craftingRecipeTracker;
+    private EntityStuckTracker entityStuckTracker;
     // Renderers
     private CommandStatusOverlay commandStatusOverlay;
     private AltoClefTickChart altoClefTickChart;
@@ -188,6 +189,7 @@ public class AltoClef implements ModInitializer {
         chunkTracker = new SimpleChunkTracker(this);
         miscBlockTracker = new MiscBlockTracker(this);
         craftingRecipeTracker = new CraftingRecipeTracker(trackerManager);
+        entityStuckTracker = new EntityStuckTracker(trackerManager);
 
         // Renderers
         commandStatusOverlay = new CommandStatusOverlay();
@@ -358,6 +360,8 @@ public class AltoClef implements ModInitializer {
 
     private void initializeBaritoneSettings() {
         getExtraBaritoneSettings().canWalkOnEndPortal(false);
+        // avoid block place on stuck entity
+        getExtraBaritoneSettings().avoidBlockPlace(entityStuckTracker::isBlockedByEntity);
         getClientBaritoneSettings().freeLook.value = false;
         getClientBaritoneSettings().overshootTraverse.value = false;
         getClientBaritoneSettings().allowOvershootDiagonalDescend.value = true;

--- a/src/main/java/adris/altoclef/chains/UnstuckChain.java
+++ b/src/main/java/adris/altoclef/chains/UnstuckChain.java
@@ -180,7 +180,8 @@ public class UnstuckChain extends SingleTaskChain {
                     var toPlace = b.getPathingBehavior().getCurrent().toPlace();
                     if (toPlace.size() != 0) {
                         Vec3d camPos = LookHelper.getCameraPos(AltoClef.getInstance());
-                        Optional<BlockPos> closestPlace = toPlace.stream().min(StlHelper.compareValues(bpos -> camPos.distanceTo(bpos.toCenterPos())));
+
+                        Optional<BlockPos> closestPlace = toPlace.stream().min(StlHelper.compareValues(bpos -> camPos.distanceTo(WorldHelper.toVec3d(bpos))));
                         if (closestPlace.isPresent()) {
                             BlockPos f = closestPlace.get();
                             placeBlockGoToBlock = f;

--- a/src/main/java/adris/altoclef/chains/UnstuckChain.java
+++ b/src/main/java/adris/altoclef/chains/UnstuckChain.java
@@ -1,16 +1,23 @@
 package adris.altoclef.chains;
 
+import java.util.LinkedList;
+import java.util.Optional;
+
 import adris.altoclef.AltoClef;
 import adris.altoclef.Debug;
 import adris.altoclef.multiversion.entity.PlayerVer;
 import adris.altoclef.multiversion.versionedfields.Blocks;
 import adris.altoclef.tasks.construction.DestroyBlockTask;
 import adris.altoclef.tasks.movement.GetOutOfWaterTask;
+import adris.altoclef.tasks.movement.GetToBlockTask;
 import adris.altoclef.tasks.movement.SafeRandomShimmyTask;
 import adris.altoclef.tasksystem.TaskRunner;
+import adris.altoclef.util.helpers.LookHelper;
+import adris.altoclef.util.helpers.StlHelper;
 import adris.altoclef.util.helpers.StorageHelper;
 import adris.altoclef.util.helpers.WorldHelper;
 import adris.altoclef.util.time.TimerGame;
+import baritone.Baritone;
 import baritone.api.utils.input.Input;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.EndPortalFrameBlock;
@@ -18,20 +25,26 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.hit.EntityHitResult;
+import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
-
-import java.util.LinkedList;
-import java.util.Optional;
 
 public class UnstuckChain extends SingleTaskChain {
 
     private final LinkedList<Vec3d> posHistory = new LinkedList<>();
     private boolean isProbablyStuck = false;
+
     private int eatingTicks = 0;
     private boolean interruptedEating = false;
+
     private TimerGame shimmyTaskTimer = new TimerGame(5);
     private boolean startedShimmying = false;
+
+    private TimerGame placeBlockTimeout = new TimerGame(2);
+
+    private TimerGame placeBlockGoToBlockTimeout = new TimerGame(5);
+    private BlockPos placeBlockGoToBlock = null;
 
     public UnstuckChain(TaskRunner runner) {
         super(runner);
@@ -138,6 +151,62 @@ public class UnstuckChain extends SingleTaskChain {
         }
     }
 
+    // Baritone might try to place a block THROUGH an entity. Detect this here
+    private void checkEntityBlocksPlacement() {
+
+        Baritone b = AltoClef.getInstance().getClientBaritone();
+
+        if (b.getPathingBehavior().getCurrent() != null) {
+            var toPlace2 = b.getPathingBehavior().getCurrent().toPlace();
+            if (toPlace2.size() != 0) {
+                Vec3d camPos = LookHelper.getCameraPos(AltoClef.getInstance());
+                Optional<BlockPos> temp = toPlace2.stream().min(StlHelper.compareValues(bpos -> camPos.distanceTo(bpos.toCenterPos())));
+                if (temp.isPresent()) {
+                    System.out.println("ASDF PLACING: " + temp.get());
+                }
+            }    
+        }
+
+        // must be pathing and trying to right click
+        if (!b.getPathingBehavior().isPathing()) {
+            placeBlockTimeout.reset();
+            return;
+        }
+        if (!b.getInputOverrideHandler().isInputForcedDown(Input.CLICK_RIGHT)) {
+            placeBlockTimeout.reset();
+            return;
+        }
+        // must be LOOKING at an entity
+
+        HitResult result = MinecraftClient.getInstance().crosshairTarget;
+
+        if (result == null || result.getType() != HitResult.Type.ENTITY) {
+            placeBlockTimeout.reset();
+            return;            
+        }
+        if (result instanceof EntityHitResult) {
+            if (placeBlockTimeout.elapsed()) {
+                if (b.getPathingBehavior().getCurrent() != null) {
+                    // We tried placing too long through this entity, get out of here!
+                    var toPlace = b.getPathingBehavior().getCurrent().toPlace();
+                    if (toPlace.size() != 0) {
+                        Vec3d camPos = LookHelper.getCameraPos(AltoClef.getInstance());
+                        Optional<BlockPos> closestPlace = toPlace.stream().min(StlHelper.compareValues(bpos -> camPos.distanceTo(bpos.toCenterPos())));
+                        if (closestPlace.isPresent()) {
+                            BlockPos f = closestPlace.get();
+                            placeBlockGoToBlock = f;
+                            placeBlockGoToBlockTimeout.reset();    
+                        }
+                    }
+                }
+                placeBlockTimeout.reset();
+            }
+            return;
+        }
+
+        placeBlockTimeout.reset();
+    }
+
     @Override
     public float getPriority() {
         if (mainTask instanceof GetOutOfWaterTask && mainTask.isActive()) {
@@ -165,17 +234,27 @@ public class UnstuckChain extends SingleTaskChain {
         checkStuckInPowderedSnow();
         checkEatingGlitch();
         checkStuckOnEndPortalFrame(mod);
-
+        checkEntityBlocksPlacement();
 
         if (isProbablyStuck) {
             return 55;
         }
 
+        // Shimmy out of the way
         if (startedShimmying && !shimmyTaskTimer.elapsed()) {
             setTask(new SafeRandomShimmyTask());
             return 55;
         }
         startedShimmying = false;
+
+        // We might place blocks but an entity blocks us
+        if (placeBlockGoToBlockTimeout.elapsed()) {
+            placeBlockGoToBlock = null;
+        }
+        if (placeBlockGoToBlock != null) {
+            setTask(new GetToBlockTask(placeBlockGoToBlock, false));
+            return 55;
+        }
 
         return Float.NEGATIVE_INFINITY;
     }

--- a/src/main/java/adris/altoclef/chains/UnstuckChain.java
+++ b/src/main/java/adris/altoclef/chains/UnstuckChain.java
@@ -156,17 +156,6 @@ public class UnstuckChain extends SingleTaskChain {
 
         Baritone b = AltoClef.getInstance().getClientBaritone();
 
-        if (b.getPathingBehavior().getCurrent() != null) {
-            var toPlace2 = b.getPathingBehavior().getCurrent().toPlace();
-            if (toPlace2.size() != 0) {
-                Vec3d camPos = LookHelper.getCameraPos(AltoClef.getInstance());
-                Optional<BlockPos> temp = toPlace2.stream().min(StlHelper.compareValues(bpos -> camPos.distanceTo(bpos.toCenterPos())));
-                if (temp.isPresent()) {
-                    System.out.println("ASDF PLACING: " + temp.get());
-                }
-            }    
-        }
-
         // must be pathing and trying to right click
         if (!b.getPathingBehavior().isPathing()) {
             placeBlockTimeout.reset();

--- a/src/main/java/adris/altoclef/commands/BlockScanner.java
+++ b/src/main/java/adris/altoclef/commands/BlockScanner.java
@@ -84,7 +84,7 @@ public class BlockScanner {
         return blacklist.unreachable(pos);
     }
 
-    public List<BlockPos> getKnownLocations(Block... blocks) {
+    public List<BlockPos> getKnownLocationsIncludeUnreachable(Block... blocks) {
         List<BlockPos> locations = new LinkedList<>();
 
         for (Block block : blocks) {
@@ -92,8 +92,14 @@ public class BlockScanner {
 
             locations.addAll(trackedBlocks.get(block));
         }
-        locations.removeIf(this::isUnreachable);
 
+        return locations;
+
+    }
+
+    public List<BlockPos> getKnownLocations(Block... blocks) {
+        List<BlockPos> locations = getKnownLocationsIncludeUnreachable(blocks);
+        locations.removeIf(this::isUnreachable);
         return locations;
     }
 

--- a/src/main/java/adris/altoclef/trackers/EntityStuckTracker.java
+++ b/src/main/java/adris/altoclef/trackers/EntityStuckTracker.java
@@ -24,8 +24,9 @@ public class EntityStuckTracker extends Tracker {
 
     public boolean isBlockedByEntity(BlockPos pos) {
         ensureUpdated();
-        boolean result = _blockedSpots.contains(pos);
-        return result;
+        synchronized (BaritoneHelper.MINECRAFT_LOCK) {
+            return _blockedSpots.contains(pos);
+        }
     }
 
     @Override

--- a/src/main/java/adris/altoclef/trackers/EntityStuckTracker.java
+++ b/src/main/java/adris/altoclef/trackers/EntityStuckTracker.java
@@ -1,0 +1,58 @@
+package adris.altoclef.trackers;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import adris.altoclef.util.helpers.BaritoneHelper;
+import adris.altoclef.util.helpers.WorldHelper;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.BlockPos;
+
+public class EntityStuckTracker extends Tracker {
+
+    final float MOB_RANGE = 25;
+
+    private final Set<BlockPos> _blockedSpots = new HashSet<>();
+
+    public EntityStuckTracker(TrackerManager manager) {
+        super(manager);
+    }
+
+
+    public boolean isBlockedByEntity(BlockPos pos) {
+        return _blockedSpots.contains(pos);
+    }
+
+    @Override
+    protected synchronized void updateState() {
+        // Go through every entity within a certain radius of the player
+        synchronized (BaritoneHelper.MINECRAFT_LOCK) {
+
+            _blockedSpots.clear();
+
+            Entity player = MinecraftClient.getInstance().player;
+            // Loop through all entities and track 'em
+            for (Entity entity : MinecraftClient.getInstance().world.getEntities()) {
+
+                if (entity == null || !entity.isAlive()) continue;
+
+                // Don't be blocked by ourselves.
+                if (entity.equals(player)) continue;
+
+                if (!player.isInRange(entity, MOB_RANGE)) continue;
+                Box b = entity.getBoundingBox();
+                for (BlockPos p : WorldHelper.getBlocksTouchingBox(b)) {
+                    _blockedSpots.add(p);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void reset() {
+        _blockedSpots.clear();
+    }
+}

--- a/src/main/java/adris/altoclef/trackers/EntityStuckTracker.java
+++ b/src/main/java/adris/altoclef/trackers/EntityStuckTracker.java
@@ -23,7 +23,9 @@ public class EntityStuckTracker extends Tracker {
 
 
     public boolean isBlockedByEntity(BlockPos pos) {
-        return _blockedSpots.contains(pos);
+        ensureUpdated();
+        boolean result = _blockedSpots.contains(pos);
+        return result;
     }
 
     @Override

--- a/src/main/java/adris/altoclef/trackers/UserBlockRangeTracker.java
+++ b/src/main/java/adris/altoclef/trackers/UserBlockRangeTracker.java
@@ -1,0 +1,56 @@
+package adris.altoclef.trackers;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import adris.altoclef.util.helpers.BaritoneHelper;
+import adris.altoclef.util.helpers.ItemHelper;
+import net.minecraft.block.Block;
+import net.minecraft.util.math.BlockPos;
+
+public class UserBlockRangeTracker extends Tracker {
+
+    // TODO: Config
+    final float AVOID_BREAKING_VOXEL_SIZE = 8;
+    final Block[] USER_BLOCKS = ItemHelper.itemsToBlocks(ItemHelper.BED);
+
+    private final Set<Vec3i> _dontBreakVoxels = new HashSet<>();
+
+    public UserBlockRangeTracker(TrackerManager manager) {
+        super(manager);
+    }
+
+    private Vec3i blockPosToVoxel(BlockPos pos) {
+        return new Vec3i(pos.getX() / AVOID_BREAKING_VOXEL_SIZE, pos.getY() / AVOID_BREAKING_VOXEL_SIZE, pos.getZ() / AVOID_BREAKING_VOXEL_SIZE);
+    }
+
+    public boolean isNearUserTrackedBlock(BlockPos pos) {
+        ensureUpdated();
+        synchronized (BaritoneHelper.MINECRAFT_LOCK) {
+            return _dontBreakVoxels.contains(blockPosToVoxel(pos));
+        }
+    }
+
+    @Override
+    protected void updateState() {
+        _dontBreakVoxels.clear();
+        List<BlockPos> userBlocks = AltoClef.getInstance().getBlockScanner().getKnownLocationsIncludeUnreachable(USER_BLOCKS);
+        for (BlockPos userBlockPos : userBlocks) {
+            Vec3i v = bloxkPosToVoxel(userBlockPos);
+            for (int dx = -1; dx <= 1; ++dx) {
+                for (int dz = -1; dz <= 1; ++dz) {
+                    for (int dy = -1; dy <= 1; ++dy) {
+                        Vec3i vToAvoid = new Vec3i(v.getX() + dx, v.getY() + dy, v.getZ() + dz);
+                        _dontBreakVoxels.add(vToAvoid);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void reset() {
+        _dontBreakVoxels.clear();
+    }
+    
+}

--- a/src/main/java/adris/altoclef/trackers/UserBlockRangeTracker.java
+++ b/src/main/java/adris/altoclef/trackers/UserBlockRangeTracker.java
@@ -38,6 +38,18 @@ public class UserBlockRangeTracker extends Tracker {
     protected void updateState() {
         _dontBreakVoxels.clear();
         List<BlockPos> userBlocks = AltoClef.getInstance().getBlockScanner().getKnownLocationsIncludeUnreachable(USER_BLOCKS);
+        // filter out user blocks
+        // TODO: is this a bad idea for the tracker...
+        userBlocks.removeIf(bpos -> {
+            Block b = AltoClef.getInstance().getWorld().getBlockState(bpos).getBlock();
+            for (Block check : USER_BLOCKS) {
+                if (check == b) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
         for (BlockPos userBlockPos : userBlocks) {
             Vec3i v = blockPosToVoxel(userBlockPos);
             for (int dx = -1; dx <= 1; ++dx) {

--- a/src/main/java/adris/altoclef/trackers/UserBlockRangeTracker.java
+++ b/src/main/java/adris/altoclef/trackers/UserBlockRangeTracker.java
@@ -1,17 +1,20 @@
 package adris.altoclef.trackers;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import adris.altoclef.AltoClef;
 import adris.altoclef.util.helpers.BaritoneHelper;
 import adris.altoclef.util.helpers.ItemHelper;
 import net.minecraft.block.Block;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3i;
 
 public class UserBlockRangeTracker extends Tracker {
 
     // TODO: Config
-    final float AVOID_BREAKING_VOXEL_SIZE = 8;
+    final int AVOID_BREAKING_VOXEL_SIZE = 8;
     final Block[] USER_BLOCKS = ItemHelper.itemsToBlocks(ItemHelper.BED);
 
     private final Set<Vec3i> _dontBreakVoxels = new HashSet<>();
@@ -36,7 +39,7 @@ public class UserBlockRangeTracker extends Tracker {
         _dontBreakVoxels.clear();
         List<BlockPos> userBlocks = AltoClef.getInstance().getBlockScanner().getKnownLocationsIncludeUnreachable(USER_BLOCKS);
         for (BlockPos userBlockPos : userBlocks) {
-            Vec3i v = bloxkPosToVoxel(userBlockPos);
+            Vec3i v = blockPosToVoxel(userBlockPos);
             for (int dx = -1; dx <= 1; ++dx) {
                 for (int dz = -1; dz <= 1; ++dz) {
                     for (int dy = -1; dy <= 1; ++dy) {


### PR DESCRIPTION
### Prevent mining near user-built structures by implementing a 16-block protection radius around player-placed blocks in `AltoClef`
Implements block protection around user structures through:

* Adds new `UserBlockRangeTracker` in [`UserBlockRangeTracker.java`](https://github.com/elefant-ai/chatclef/pull/54/files#diff-de602e75a6fa8410febd719525a1ad2047b3616109705a5ba963327c8cce0619) that identifies and protects blocks within 16 blocks of player-built structures
* Integrates tracker with Baritone settings in [`AltoClef.java`](https://github.com/elefant-ai/chatclef/pull/54/files#diff-d367ff97b960553c1363b112e7e24e8135753dacd064485925543550cbb31be8) to prevent breaking protected blocks
* Modifies `BlockScanner` in [`BlockScanner.java`](https://github.com/elefant-ai/chatclef/pull/54/files#diff-84b78a3408c89015f25a6d8476f9b3b1e7c4b5a60d18306da2b37c9fb7337cb0) to expose unreachable block locations
* Updates block position calculation in [`UnstuckChain.java`](https://github.com/elefant-ai/chatclef/pull/54/files#diff-afdf519813be3e69ee054f0ba9779c615b7ac5e9cacd067755557d2790ad272b) using `WorldHelper.toVec3d()`

#### 📍Where to Start
Start with the `UserBlockRangeTracker` class in [`UserBlockRangeTracker.java`](https://github.com/elefant-ai/chatclef/pull/54/files#diff-de602e75a6fa8410febd719525a1ad2047b3616109705a5ba963327c8cce0619) which defines the core protection logic, then follow the integration in `AltoClef` class initialization.

----

_[Macroscope](https://app.macroscope.com) summarized 8890baa._