### PR TITLE
5/8/25 release patch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.warning.mode=all
 
 loader_version=0.16.2
 # Mod Properties
-mod_version=0.18.22
+mod_version=0.18.23
 
 maven_group=gaucho-matrero.altoclef
 archives_base_name=chatclef

--- a/src/main/java/adris/altoclef/Settings.java
+++ b/src/main/java/adris/altoclef/Settings.java
@@ -637,7 +637,7 @@ public class Settings implements IFailableConfigFile {
     public boolean isPositionExplicitlyProtected(BlockPos pos) {
         if (!areasToProtect.isEmpty()) {
             for (BlockRange protection : areasToProtect) {
-                if (protection.contains(pos)) return true;
+                if (protection != null && protection.isValid() && protection.contains(pos)) return true;
             }
         }
         return false;

--- a/src/main/java/adris/altoclef/trackers/UserBlockRangeTracker.java
+++ b/src/main/java/adris/altoclef/trackers/UserBlockRangeTracker.java
@@ -21,8 +21,9 @@ public class UserBlockRangeTracker extends Tracker {
     final int AVOID_BREAKING_RANGE = 16;
 
     final Block[] USER_INDICATOR_BLOCKS = Streams.concat(
-        Arrays.stream(ItemHelper.itemsToBlocks(ItemHelper.BED)),
-        Arrays.asList(Blocks.CHEST, Blocks.TRAPPED_CHEST, Blocks.FLETCHING_TABLE, Blocks.ANVIL).stream()
+        Arrays.stream(ItemHelper.itemsToBlocks(ItemHelper.BED))
+        // maybe add these in later, no need
+        // Arrays.asList(Blocks.CHEST, Blocks.TRAPPED_CHEST, Blocks.FLETCHING_TABLE, Blocks.ANVIL).stream()
     ).toArray(Block[]::new);
 
     final Block[] USER_BLOCKS_TO_AVOID_BREAKING = Streams.concat(

--- a/src/main/java/adris/altoclef/util/BlockRange.java
+++ b/src/main/java/adris/altoclef/util/BlockRange.java
@@ -25,6 +25,10 @@ public class BlockRange {
         return contains(pos, WorldHelper.getCurrentDimension());
     }
 
+    public boolean isValid() {
+        return start != null && end != null;
+    }
+
     public boolean contains(BlockPos pos, Dimension dimension) {
         if (this.dimension != dimension)
             return false;


### PR DESCRIPTION
### Update mod version to 0.18.23 and improve BlockRange validation in Settings and UserBlockRangeTracker
* Add null and validity checking for `BlockRange` objects in `isPositionExplicitlyProtected` method within [Settings.java](https://github.com/elefant-ai/chatclef/pull/56/files#diff-249113e275f5d4f079a50758dfb6e724faab676d61bea923796bb5ba320f6c6b)
* Introduce `isValid()` method in [BlockRange.java](https://github.com/elefant-ai/chatclef/pull/56/files#diff-1cd70330b0d157ade14964226c20c1255e58d47ccffda48322c9076037511373) to validate start and end positions
* Modify `USER_INDICATOR_BLOCKS` in [UserBlockRangeTracker.java](https://github.com/elefant-ai/chatclef/pull/56/files#diff-de602e75a6fa8410febd719525a1ad2047b3616109705a5ba963327c8cce0619) to only include bed blocks
* Update mod version from 0.18.22 to 0.18.23 in [gradle.properties](https://github.com/elefant-ai/chatclef/pull/56/files#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19)

#### 📍Where to Start
Start with the `isPositionExplicitlyProtected` method in [Settings.java](https://github.com/elefant-ai/chatclef/pull/56/files#diff-249113e275f5d4f079a50758dfb6e724faab676d61bea923796bb5ba320f6c6b) which contains the core validation changes.

----

_[Macroscope](https://app.macroscope.com) summarized 288d57f._